### PR TITLE
Simplify webserver logic

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -16,8 +16,7 @@
                 "electron-unhandled": "~4.0.1",
                 "electron-updater": "^6.6.2",
                 "electron-window-state": "^5.0.3",
-                "express": "^5.2.1",
-                "http-proxy-middleware": "^3.0.5"
+                "express": "^5.2.1"
             },
             "devDependencies": {
                 "@types/express": "^5.0.6",
@@ -1061,15 +1060,6 @@
             "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@types/http-proxy": {
-            "version": "1.17.17",
-            "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.17.tgz",
-            "integrity": "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
         },
         "node_modules/@types/keyv": {
             "version": "3.1.4",
@@ -3696,12 +3686,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/eventemitter3": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-            "license": "MIT"
-        },
         "node_modules/events": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -3912,26 +3896,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
             }
         },
         "node_modules/foreground-child": {
@@ -4439,20 +4403,6 @@
                 "url": "https://opencollective.com/express"
             }
         },
-        "node_modules/http-proxy": {
-            "version": "1.18.1",
-            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-            "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-            "license": "MIT",
-            "dependencies": {
-                "eventemitter3": "^4.0.0",
-                "follow-redirects": "^1.0.0",
-                "requires-port": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
         "node_modules/http-proxy-agent": {
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -4465,23 +4415,6 @@
             },
             "engines": {
                 "node": ">= 14"
-            }
-        },
-        "node_modules/http-proxy-middleware": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
-            "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/http-proxy": "^1.17.15",
-                "debug": "^4.3.6",
-                "http-proxy": "^1.18.1",
-                "is-glob": "^4.0.3",
-                "is-plain-object": "^5.0.0",
-                "micromatch": "^4.0.8"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/http2-wrapper": {
@@ -4726,15 +4659,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
-            }
-        },
-        "node_modules/is-plain-object": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/is-promise": {
@@ -5065,19 +4989,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/micromatch": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-            "license": "MIT",
-            "dependencies": {
-                "braces": "^3.0.3",
-                "picomatch": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=8.6"
             }
         },
         "node_modules/mime": {
@@ -6003,12 +5914,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/requires-port": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-            "license": "MIT"
         },
         "node_modules/resedit": {
             "version": "1.7.2",

--- a/electron/package.json
+++ b/electron/package.json
@@ -28,8 +28,7 @@
         "electron-unhandled": "~4.0.1",
         "electron-updater": "^6.6.2",
         "electron-window-state": "^5.0.3",
-        "express": "^5.2.1",
-        "http-proxy-middleware": "^3.0.5"
+        "express": "^5.2.1"
     },
     "devDependencies": {
         "@types/express": "^5.0.6",

--- a/electron/src/index.ts
+++ b/electron/src/index.ts
@@ -9,10 +9,6 @@ import electronIsDev from "electron-is-dev";
 import unhandled from "electron-unhandled";
 import express from "express";
 import net from "net";
-import {
-    createProxyMiddleware,
-    responseInterceptor,
-} from "http-proxy-middleware";
 
 import {
     ElectronCapacitorApp,
@@ -93,44 +89,18 @@ async function startWebServer() {
         ? path.join(process.resourcesPath, "app.asar", "app")
         : path.join(app.getAppPath(), "app");
 
-    server.use(
-        "/api/ets2",
-        createProxyMiddleware({
-            target: "http://localhost:25555/api/ets2/telemetry",
-            changeOrigin: true,
-            selfHandleResponse: true,
-            on: {
-                proxyRes: responseInterceptor(
-                    async (responseBuffer, proxyRes) => {
-                        if (
-                            proxyRes.headers["content-type"]?.includes(
-                                "application/json",
-                            )
-                        ) {
-                            try {
-                                const data = JSON.parse(
-                                    responseBuffer.toString("utf8"),
-                                );
-                                const wrappedResponse = {
-                                    connected: true,
-                                    telemetry: data,
-                                };
-
-                                return JSON.stringify(wrappedResponse);
-                            } catch (e) {
-                                console.error(
-                                    "Failed to parse telemetry JSON",
-                                    e,
-                                );
-                            }
-                        }
-
-                        return responseBuffer;
-                    },
-                ),
-            },
-        }),
-    );
+    server.get("/api/ets2", async (_req, res) => {
+        var response = await fetchTelemetry("localhost");
+        if (response) {
+            const wrappedResponse = {
+                connected: true,
+                telemetry: await response,
+            };
+            res.json(wrappedResponse);
+        } else {
+            res.json({ connected: false, telemetry: null });
+        }
+    });
 
     server.use(express.static(webDir));
 
@@ -167,6 +137,21 @@ async function getAvailablePort(startingPort: number): Promise<number> {
     });
 }
 
+async function fetchTelemetry(ip: string | "localhost") {{
+    try {
+        const response = await fetch(`http://${ip}:25555/api/ets2/telemetry`);
+        if (!response.ok) {
+            console.warn(`Telemetry fetch failed with status ${response.status}: ${response.statusText}`);
+
+            return null;
+        } 
+
+        return await response.json();
+    } catch {
+        return null;
+    }
+}};
+
 ipcMain.handle("get-local-port", () => {
     return currentPort.value;
 });
@@ -195,13 +180,7 @@ ipcMain.handle("get-local-ip", async () => {
 });
 
 ipcMain.handle("fetch-telemetry", async (_event, ip) => {
-    try {
-        const response = await fetch(`http://${ip}:25555/api/ets2/telemetry`);
-        if (!response.ok) return null;
-        return await response.json();
-    } catch {
-        return null;
-    }
+    return await fetchTelemetry(ip);
 });
 
 ipcMain.on("open-external", (_event, url) => {


### PR DESCRIPTION
I know I just submitted yesterday, sorry for being a pain. However, I noticed I was over complicating things. 

Changes:
- Removed http-proxy-middleware dependency. 
- Simpliflied telemetry fetching when using express webserver in electron app. 
- Created Fetch Telemetry function that answers for both express and ipcMain

Hopefully that's a lot cleaner and easier to maintain.