### PR TITLE
feat(ATS): implement Real Companies Mod Compatibility Patch

### DIFF
--- a/app/components/Settings/settingsPanel.vue
+++ b/app/components/Settings/settingsPanel.vue
@@ -8,9 +8,6 @@ const props = defineProps<{ closePanel: () => void }>();
 
 const isDlcPanelOpened = ref(false);
 const isMetric = computed(() => activeSettings.value.units === "metric");
-const isRealisticCompanyNamesEnabled = computed(
-    () => activeSettings.value.useRealisticCompanyNames
-);
 
 const selectedExpansion = computed(() => {
     return settings.value.selectedGame === "ets2"
@@ -22,13 +19,9 @@ const toggleDlcPanel = () => {
     isDlcPanelOpened.value = !isDlcPanelOpened.value;
 };
 
-    function toggleUnits() {
-        updateProfile("units", isMetric.value ? "imperial" : "metric");
-    }
-
-    function toggleRealisticCompanyNames() {
-        updateProfile("useRealisticCompanyNames", !isRealisticCompanyNamesEnabled.value);
-    }
+function toggleUnits() {
+    updateProfile("units", isMetric.value ? "imperial" : "metric");
+}
 </script>
 
 <template>
@@ -93,24 +86,6 @@ const toggleDlcPanel = () => {
                 <button class="segment-btn" :class="{ active: !isMetric }">
                     <span class="label">Imperial</span>
                 </button>
-            </div>
-        </div>
-
-        <div class="option setting">
-            <div class="option-title">
-                <Icon name="lucide:map-plus" size="24" />
-                <p>Enable Realistic Company Names Mod Compatability</p>
-            </div>
-            <div class="owned-dlcs">
-                <div class="segmented-control" @click="toggleRealisticCompanyNames">
-                    <button class="segment-btn" :class="{ active: isRealisticCompanyNamesEnabled }">
-                        <span class="label">On</span>
-                    </button>
-
-                    <button class="segment-btn" :class="{ active: !isRealisticCompanyNamesEnabled }">
-                        <span class="label">Off</span>
-                    </button>
-                </div>
             </div>
         </div>
 

--- a/app/composables/CityData.ts
+++ b/app/composables/CityData.ts
@@ -1,4 +1,3 @@
-import { shallowRef, ref } from "vue";
 import {
     convertGeoToAts,
     convertGeoToEts2,
@@ -39,11 +38,11 @@ interface CityFallback {
 }
 
 interface RealCompanyModFallback {
-  [key: string]: {
-    name: string
-    sort_name: string
-    trailer_look: string
-  }
+    [companyId: string]: {
+        name: string;
+        sort_name: string;
+        trailer_look: string;
+    };
 }
 
 const cityData = shallowRef<GeoJsonCollection | null>(null);
@@ -83,16 +82,19 @@ export function useCityData() {
                 if (citiesFallbackRes.ok)
                     citiesFallbackData.value = await citiesFallbackRes.json();
             } else if (settings.value.selectedGame == "ats") {
-                const [citiesRes, companiesRes, realCompanyModRes] = await Promise.all([
-                    fetch("/data/ats/map-data/cities.geojson"),
-                    fetch("/data/ats/map-data/companies.geojson"),
-                    settings.value.profiles.ats.useRealisticCompanyNames ? fetch("/data/ats/map-data/RealCompaniesModVanillaMapping.json") : Promise.resolve(null),
-                ]);
+                const [citiesRes, companiesRes, realCompanyModRes] =
+                    await Promise.all([
+                        fetch("/data/ats/map-data/cities.geojson"),
+                        fetch("/data/ats/map-data/companies.geojson"),
+                        fetch(
+                            "/data/ats/map-data/RealCompaniesModVanillaMapping.json",
+                        ),
+                    ]);
 
                 if (citiesRes.ok) cityData.value = await citiesRes.json();
                 if (companiesRes.ok)
                     companiesData.value = await companiesRes.json();
-                if (realCompanyModRes && realCompanyModRes.ok)
+                if (realCompanyModRes.ok)
                     realCompanyModData.value = await realCompanyModRes.json();
             }
 
@@ -160,12 +162,17 @@ export function useCityData() {
         }
 
         const safeCompanyName = targetCompanyName.toLowerCase().trim();
-        const matchedKey = ref<string | undefined>(undefined);
-        
+        let vanillaId: string | undefined = undefined;
+
         if (realCompanyModData.value) {
-            matchedKey.value = Object.keys(realCompanyModData.value).find(key => {
+            vanillaId = Object.keys(realCompanyModData.value).find((key) => {
                 const entry = realCompanyModData.value![key];
-                return entry?.sort_name && safeCompanyName.includes(entry.sort_name.toLowerCase().trim());
+                return (
+                    entry?.sort_name &&
+                    safeCompanyName.includes(
+                        entry.sort_name.toLowerCase().trim(),
+                    )
+                );
             });
         }
 
@@ -176,7 +183,7 @@ export function useCityData() {
                 p.poiType === "company" &&
                 p.poiName &&
                 (p.poiName.toLowerCase().trim() === safeCompanyName ||
-                (matchedKey.value && p["sprite"].includes(matchedKey.value)))
+                    (vanillaId && p["sprite"].includes(vanillaId)))
             );
         });
 

--- a/app/composables/EtsTelemetry.ts
+++ b/app/composables/EtsTelemetry.ts
@@ -1,4 +1,3 @@
-import { ref, reactive, toRefs } from "vue";
 import { CapacitorHttp } from "@capacitor/core";
 import {
     getGameState,
@@ -68,12 +67,15 @@ export function useEtsTelemetry() {
                     connectTimeout: 1000,
                 });
 
-                if (response.status === 200) return response.data as TelemetryData;
-
+                if (response.status === 200)
+                    return response.data as TelemetryData;
             } else if (isWeb.value) {
                 if (abortController) abortController.abort();
                 abortController = new AbortController();
-                const timeoutId = setTimeout(() => abortController?.abort(), 1000);
+                const timeoutId = setTimeout(
+                    () => abortController?.abort(),
+                    1000,
+                );
 
                 const res = await fetch("/api/ets2", {
                     signal: abortController.signal,
@@ -85,21 +87,28 @@ export function useEtsTelemetry() {
 
                 if (res.ok) {
                     const result = await res.json();
-                    if (result.connected) return result.telemetry as TelemetryData;
+                    if (result.connected)
+                        return result.telemetry as TelemetryData;
                 }
+
+                return null;
             } else if (isElectron.value) {
                 const targetIP = settings.value.savedIP || "127.0.0.1";
-                return (await (window as any).electronAPI.fetchTelemetry(targetIP)) as TelemetryData;
+                return (await (window as any).electronAPI.fetchTelemetry(
+                    targetIP,
+                )) as TelemetryData;
             }
         } catch (err) {
-            if (err instanceof Error && err.name !== "AbortError") console.log(err);
+            if (err instanceof Error && err.name !== "AbortError")
+                console.log(err);
         }
-        
+
         return null;
     }
 
     function startTelemetry(onUpdate?: (data: TelemetryUpdate) => void) {
         if (isRunning.value) return;
+
         isRunning.value = true;
         currentSessionId++;
         const mySessionId = currentSessionId;

--- a/app/composables/Settings.ts
+++ b/app/composables/Settings.ts
@@ -8,7 +8,6 @@ export interface GameProfile {
     routeColor: string;
     units: UnitSystem;
     ownedDlcs: number[];
-    useRealisticCompanyNames: boolean;
     lastDestination: [number, number] | null;
 }
 
@@ -26,7 +25,6 @@ const DEFAULT_PROFILE: GameProfile = {
     routeColor: "#22d3ee",
     units: "metric",
     ownedDlcs: Array.from({ length: 10 }, (_, i) => i + 1),
-    useRealisticCompanyNames: false,
     lastDestination: null,
 };
 
@@ -34,13 +32,12 @@ const DEFAULT_SETTINGS: AppSettingsState = {
     selectedGame: null,
     savedIP: null,
     profiles: {
-        ets2: { ...DEFAULT_PROFILE, themeColor: "#fbc02d", units: "metric", useRealisticCompanyNames: false },
+        ets2: { ...DEFAULT_PROFILE, themeColor: "#fbc02d", units: "metric" },
         ats: {
             ...DEFAULT_PROFILE,
             themeColor: "#d32f2f",
             ownedDlcs: Array.from({ length: 16 }, (_, i) => i + 1),
             units: "imperial",
-            useRealisticCompanyNames: false,
         },
     },
 };


### PR DESCRIPTION
* Added Mapping file from Real Companies Mod to ATS. ETS2 still needed.
* Modded Company Names will be read during `loadLocationData`
* Added a settings feature flag to enable/disable compatibility patch. mapping file will not be read when disabled. 
* After defining `safeCompanyName` we check the modded company mapping file to check if the safeCompanyName shows up there. If it does we return its key. 
* Lastly, when getting companyCandidates, we compare if `p.poiName` equals `safeCompanyName` or if `p["sprite"]` equals the `matchedKey`. I did this because the mod overwrites the company name, but the company sprite remains the same. 

Downside to this approach, anytime the mod updates will need to generate the mapping json file. I included the one I generated in public/data/ats/map-data/RealCompaniesModVanillaMapping.json. I generated the file by going to the modded company mapping folder and copying the .scs file. I renamed it .zip extracted and went to the def/company sub folder. I ran a small script that read each of the sui files and copied them into a single json file. 

Lastly, I had separately refactored EtsTelemetry to reduce code duplication by separating telemetry fetching from processing. I forgot I had that when I committed my changes. Feel free to take it or leave it.

