### PR TITLE
Add Turn Based Navigation

### DIFF
--- a/app/assets/scss/scoped/map/map.scss
+++ b/app/assets/scss/scoped/map/map.scss
@@ -80,3 +80,13 @@
     align-items: flex-end;
     gap: 0.8rem;
 }
+
+.turn-navigation-overlay {
+    position: absolute;
+    top: calc(20px + $game-info-bar-height);
+    left: 55px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.8rem;
+}

--- a/app/assets/scss/scoped/map/map.scss
+++ b/app/assets/scss/scoped/map/map.scss
@@ -87,6 +87,4 @@
     left: 55px;
     display: flex;
     flex-direction: column;
-    align-items: flex-end;
-    gap: 0.8rem;
 }

--- a/app/assets/utils/routing/algorithm.ts
+++ b/app/assets/utils/routing/algorithm.ts
@@ -5,7 +5,9 @@ import {
     getSignedAngle,
 } from "~/assets/utils/map/maths";
 import { convertGeoToAts, convertGeoToEts2 } from "../map/converters";
+import { evaluateJunction } from "./turnInstructions";
 import type { GameType } from "~/types";
+import type { TurnInstruction } from "./turnInstructions";
 
 const MAX_NODES = 900000;
 
@@ -95,7 +97,7 @@ export const calculateRoute = (
     startType: "road" | "yard" = "road",
     ownedDlcs: number[],
     targetLocation?: [number, number],
-): { path: [number, number][]; endId: number } | null => {
+): { path: [number, number][]; endId: number, pathNodeIds: number[], turnInstructions: TurnInstruction[] } | null => {
     ensureCoordCache(nodeCoords);
     const flatCoords = cache_flatCoords!;
 
@@ -305,15 +307,44 @@ export const calculateRoute = (
     if (foundEndId === null) return null;
 
     const path: [number, number][] = [];
+    const pathNodeIds: number[] = [];
+    const turnInstructions: Omit<TurnInstruction, "distance" & { distance: number }>[] = [];
     let curr: number = foundEndId;
+    let nextId: number = -1;
 
     while (curr !== -1) {
+        const prevId = cache_previous[curr]!;
+ 
+        if (nextId !== -1 && prevId !== -1) {
+            const instruction = evaluateJunction(
+                prevId,
+                curr,
+                nextId,
+                path.length,
+                adjacency,
+                flatCoords,
+            );
+            
+            if (instruction) {
+                turnInstructions.push({ ...instruction, distance: 0 });
+            }
+        }
+
         path.unshift([flatCoords[curr * 2]!, flatCoords[curr * 2 + 1]!]);
+        pathNodeIds.unshift(curr);
+        nextId = curr;
         curr = cache_previous[curr]!;
         if (path.length > 20000) break;
     }
 
-    return { path, endId: foundEndId };
+    turnInstructions.push({
+        pathIndex: path.length - 1,
+        type: "destination",
+        description: "Arrived at destination",
+        distance: 0,
+    });
+
+    return { path, endId: foundEndId, pathNodeIds, turnInstructions };
 };
 
 export const mergeClosePoints = (

--- a/app/assets/utils/routing/helpers.ts
+++ b/app/assets/utils/routing/helpers.ts
@@ -13,3 +13,17 @@ export function haversine(a: Coord, b: Coord): number {
     const h = sin1 * sin1 + Math.cos(lat1) * Math.cos(lat2) * sin2 * sin2;
     return 2 * R * Math.asin(Math.sqrt(h));
 }
+
+export function getPathNodeIds(
+    path: [number, number][],
+    nodeCoords: Map<number, [number, number]>
+): number[] {
+    const coordKey = (c: [number, number]) => `${c[0]},${c[1]}`;
+    const coordToNode = new Map<string, number>();
+
+    for (const [id, coord] of nodeCoords) {
+        coordToNode.set(coordKey(coord), id);
+    }
+
+    return path.map((coord) => coordToNode.get(coordKey(coord)) ?? -1);
+}

--- a/app/assets/utils/routing/turnInstructions.ts
+++ b/app/assets/utils/routing/turnInstructions.ts
@@ -1,181 +1,84 @@
-import { getSignedAngle } from "~/assets/utils/map/maths";
-import type { Edge } from "./graphTypes";
-
-export type Maneuver =
-    | { kind: "turn"; index: number; angle: number }
-    | { kind: "fork"; index: number; side: "left" | "right" }
-    | { kind: "destination"; index: number };
-
 export interface TurnInstruction {
     pathIndex: number;
-    type: 'slight-left' | 'left' | 'slight-right' | 'right' | 'continue' | 'keep-left' | 'keep-right' | 'destination';
+    type:
+        | "sharp-left" | "left" | "slight-left"
+        | "sharp-right" | "right" | "slight-right"
+        | "keep-left" | "keep-right"
+        | "continue" | "destination";
     description: string;
     distance: number;
 }
 
-// Thresholds
-const HARD_TURN = 45;
-const SLIGHT_TURN = 25;
-const FORK_MIN_DOT_DIFF = 0.12;
-const CONTINUE_MIN_KM = 1.5;
-const TOLERANCE_INDICES = 5;
+const SLIGHT_DEG         = 20;
+const HARD_DEG           = 45;
+const SHARP_DEG          = 100;
+const FORK_ADVANTAGE_DEG = 15;
 
-export function generateTurnInstructions(
-    rawPath: [number, number][],
-    stats: Float32Array,
-    pathNodeIds: number[],
-    nodeCoords: Map<number, [number, number]>,
-    adjacency: Map<number, any[]>,
-): TurnInstruction[] {
-    if (rawPath.length < 2) return [{
-        pathIndex: 0,
-        type: "destination",
-        description: "Arrived at destination",
-        distance: 0,
-    }];
-
-    const maneuvers: Maneuver[] = [];
-    let skipUntil = 0;
-
-    // Identify all turns and forks
-    for (let i = 1; i < rawPath.length - 1; i++) {
-        if (i <= skipUntil) continue;
-
-        const prev = rawPath[i - 1];
-        const curr = rawPath[i];
-        const next = rawPath[i + 1];
-
-        const {angle, endIndex} = detectAngle(rawPath, i);
-        const abs = Math.abs(angle);
-
-        const currId = pathNodeIds[i];
-        const degree = currId !== undefined ? (adjacency.get(currId)?.length ?? 0) : 0;
-
-        if (degree >= 3 && currId !== undefined) {
-            const fork = detectFork(prev, curr, next, currId, adjacency, nodeCoords);
-            if (fork) {
-                maneuvers.push({ kind: "fork", index: i, side: fork });
-                skipUntil = i + TOLERANCE_INDICES;
-                continue;
-            }
-        }
-
-        if (abs >= SLIGHT_TURN) {
-            maneuvers.push({ kind: "turn", index: i, angle });
-            skipUntil = endIndex;
-        }
-    }
-
-    maneuvers.push({ kind: "destination", index: rawPath.length - 1 });
-
-    // Build instructions with "continue" lookahead
-    const instructions: TurnInstruction[] = [];
-
-    for (let i = 0; i < maneuvers.length; i++) {
-        const m = maneuvers[i];
-        const km = stats[m.index * 2];
-
-        // Insert continue for the stretch before this maneuver
-        if (i > 0) {
-            const prev = maneuvers[i - 1];
-            const startIndex = prev.index;
-            const endIndex = Math.max(m.index - TOLERANCE_INDICES, startIndex + 1);
-            const straightDistance = stats[endIndex * 2] - stats[startIndex * 2];
-
-            if (straightDistance >= CONTINUE_MIN_KM) {
-                instructions.push({
-                    pathIndex: endIndex,
-                    type: "continue",
-                    description: `Continue`,
-                    distance: stats[endIndex * 2],
-                });
-            }
-        }
-
-        // Build maneuver instruction
-        let instr: TurnInstruction | null = null;
-        if (m.kind === "turn") {
-            const type = Math.abs(m.angle) >= HARD_TURN
-                ? m.angle < 0 ? "left" : "right"
-                : m.angle < 0 ? "slight-left" : "slight-right";
-            instr = {
-                pathIndex: m.index,
-                type,
-                description: `Turn ${type.replace("-", " ")}`,
-                distance: km,
-            };
-        } else if (m.kind === "fork") {
-            instr = {
-                pathIndex: m.index,
-                type: m.side === "left" ? "keep-left" : "keep-right",
-                description: m.side === "left" ? "Keep left" : "Keep right",
-                distance: km,
-            };
-        } else if (m.kind === "destination") {
-            instr = {
-                pathIndex: m.index,
-                type: "destination",
-                description: "Arrived at destination",
-                distance: km,
-            };
-        }
-
-        if (instr) instructions.push(instr);
-    }
-
-    return instructions;
+function bearingBetween(
+    flatCoords: Float64Array,
+    fromId: number,
+    toId: number,
+): number {
+    const dLng = flatCoords[toId * 2]!     - flatCoords[fromId * 2]!;
+    const dLat = flatCoords[toId * 2 + 1]! - flatCoords[fromId * 2 + 1]!;
+    return (Math.atan2(dLng, dLat) * 180) / Math.PI;
 }
 
-export function detectFork(
-    prev: [number, number],
-    curr: [number, number],
-    next: [number, number],
+function signedAngleDiff(from: number, to: number): number {
+    return ((to - from + 540) % 360) - 180;
+}
+
+export function evaluateJunction(
+    prevId: number,
     currId: number,
-    adjacency: Map<number, Edge[]>,
-    nodeCoords: Map<number, [number, number]>
-): "keep-left" | "keep-right" | null {
+    nextId: number,
+    pathIndex: number,
+    adjacency: Map<number, { to: number; weight: number; r: number; dlc: number }[]>,
+    flatCoords: Float64Array,
+): Omit<TurnInstruction, "distance"> | null {
+
     const edges = adjacency.get(currId);
     if (!edges || edges.length < 3) return null;
 
-    const incomingAngle = Math.atan2(curr[1] - prev[1], curr[0] - prev[0]);
+    const inBearing  = bearingBetween(flatCoords, prevId, currId);
+    const outBearing = bearingBetween(flatCoords, currId, nextId);
+    const chosenDeg  = signedAngleDiff(inBearing, outBearing) * -1;
 
-    let bestDot = -Infinity;
-    let chosenDot = -Infinity;
-    let chosenAngle = 0;
+    let bestAltDeg = Infinity;
+    let altCount   = 0;
 
     for (const edge of edges) {
-        const toCoord = nodeCoords.get(edge.to);
-        if (!toCoord) continue;
+        if (edge.to === nextId) continue;
+        const exitBearing = bearingBetween(flatCoords, currId, edge.to);
+        const exitDeg     = signedAngleDiff(inBearing, exitBearing);
+        if (Math.abs(exitDeg) > 150) continue; // ignore U-turns
+        altCount++;
+        if (Math.abs(exitDeg) < Math.abs(bestAltDeg)) bestAltDeg = exitDeg;
+    }
 
-        const angle = Math.atan2(toCoord[1] - curr[1], toCoord[0] - curr[0]);
-        const dot = Math.cos(angle - incomingAngle);
+    if (altCount === 0) return null;
 
-        bestDot = Math.max(bestDot, dot);
+    const chosenAbs  = Math.abs(chosenDeg);
+    const bestAltAbs = Math.abs(bestAltDeg);
 
-        if (toCoord[0] === next[0] && toCoord[1] === next[1]) {
-            chosenDot = dot;
-            chosenAngle = angle - incomingAngle;
+    if (chosenAbs < SLIGHT_DEG && bestAltAbs < SLIGHT_DEG) {
+        if (chosenAbs - bestAltAbs > FORK_ADVANTAGE_DEG) {
+            const type = chosenDeg < 0 ? "keep-left" : "keep-right";
+            return { pathIndex, type, description: type === "keep-left" ? "Keep left" : "Keep right" };
         }
+        return null; 
     }
 
-    if (bestDot - chosenDot < FORK_MIN_DOT_DIFF) return null;
-
-    return chosenAngle < 0 ? "keep-left" : "keep-right";
-}
-
-function detectAngle(rawPath: [number, number][], i: number): { angle: number; endIndex: number } {
-    let totalAngle = 0;
-    let j = i;
-
-    while (j < rawPath.length - 1) {
-        const a = getSignedAngle(rawPath[j - 1]!, rawPath[j]!, rawPath[j + 1]!);
-
-        if (Math.sign(a) !== Math.sign(totalAngle || a)) break;
-        if (Math.abs(a) < 5) break;
-
-        totalAngle += a;
-        j++;
+    if (chosenAbs < SLIGHT_DEG) return null;
+    
+    if (bestAltAbs < chosenAbs - FORK_ADVANTAGE_DEG || chosenAbs >= HARD_DEG) {
+        const abs  = Math.abs(chosenDeg);
+        const type: TurnInstruction["type"] =
+            abs >= SHARP_DEG ? (chosenDeg < 0 ? "sharp-left"  : "sharp-right") :
+            abs >= HARD_DEG  ? (chosenDeg < 0 ? "left"        : "right")       :
+                               (chosenDeg < 0 ? "slight-left" : "slight-right");
+        return { pathIndex, type, description: `Turn ${type.replace("-", " ")}` };
     }
 
-    return { angle: totalAngle, endIndex: j };
+    return null;
 }

--- a/app/assets/utils/routing/turnInstructions.ts
+++ b/app/assets/utils/routing/turnInstructions.ts
@@ -36,10 +36,10 @@ export function evaluateJunction(
     adjacency: Map<number, { to: number; weight: number; r: number; dlc: number }[]>,
     flatCoords: Float64Array,
 ): Omit<TurnInstruction, "distance"> | null {
-
     const edges = adjacency.get(currId);
-    if (!edges || edges.length < 3) return null;
-
+    if (!edges || edges.length < 3) {
+        return null;
+    }
     const inBearing  = bearingBetween(flatCoords, prevId, currId);
     const outBearing = bearingBetween(flatCoords, currId, nextId);
     const chosenDeg  = signedAngleDiff(inBearing, outBearing) * -1;
@@ -69,8 +69,10 @@ export function evaluateJunction(
         return null; 
     }
 
-    if (chosenAbs < SLIGHT_DEG) return null;
-    
+    if (chosenAbs < SLIGHT_DEG) {
+        return { pathIndex, type: "continue", description: "Continue straight" };
+    }
+
     if (bestAltAbs < chosenAbs - FORK_ADVANTAGE_DEG || chosenAbs >= HARD_DEG) {
         const abs  = Math.abs(chosenDeg);
         const type: TurnInstruction["type"] =
@@ -81,4 +83,23 @@ export function evaluateJunction(
     }
 
     return null;
+}
+
+export function cleanInstructions(instructions: TurnInstruction[]): TurnInstruction[] {
+    let result = instructions.filter((t, i) => {
+        if (t.type === "continue") {
+            const next = instructions[i + 1];
+            if (next && next.type === "continue") return false;
+        }
+        return true;
+    });
+
+    const result2: TurnInstruction[] = [];
+    for (const t of result) {
+        const prev = result2[result2.length - 1];
+        if (prev && t.pathIndex - prev.pathIndex <= 1 && t.type !== "destination") continue;
+        result2.push(t);
+    }
+
+    return result2;
 }

--- a/app/assets/utils/routing/turnInstructions.ts
+++ b/app/assets/utils/routing/turnInstructions.ts
@@ -1,156 +1,159 @@
 import { getSignedAngle } from "~/assets/utils/map/maths";
 import type { Edge } from "./graphTypes";
 
+export type Maneuver =
+    | { kind: "turn"; index: number; angle: number }
+    | { kind: "fork"; index: number; side: "left" | "right" }
+    | { kind: "destination"; index: number };
+
 export interface TurnInstruction {
     pathIndex: number;
-    type: "slight-left" | "left" | "slight-right" | "right" | "destination";
+    type: 'slight-left' | 'left' | 'slight-right' | 'right' | 'continue' | 'keep-left' | 'keep-right' | 'destination';
     description: string;
     distance: number;
 }
 
+// Thresholds
 const HARD_TURN = 45;
 const SLIGHT_TURN = 25;
-const STRAIGHT_RESET = 10;
-const POST_TURN_SUPPRESS_KM = 0.5;
+const FORK_MIN_DOT_DIFF = 0.12;
+const CONTINUE_MIN_KM = 1.5;
+const TOLERANCE_INDICES = 5;
 
 export function generateTurnInstructions(
     rawPath: [number, number][],
     stats: Float32Array,
     pathNodeIds: number[],
+    nodeCoords: Map<number, [number, number]>,
     adjacency: Map<number, Edge[]>,
-    nodeCoords: Map<number, [number, number]>
 ): TurnInstruction[] {
-    if (rawPath.length < 3) {
-        return [{
-            pathIndex: rawPath.length - 1,
-            type: "destination",
-            description: "Arrive at destination",
-            distance: 0,
-        }];
-    }
+    if (rawPath.length < 2) return [{
+        pathIndex: 0,
+        type: "destination",
+        description: "Arrived at destination",
+        distance: 0,
+    }];
 
-    const instructions: TurnInstruction[] = [];
+    const maneuvers: Maneuver[] = [];
 
-    function tookStraightEdge(
-        prev: [number, number],
-        curr: [number, number],
-        next: [number, number],
-        currId: number
-    ): boolean {
-        const edges = adjacency.get(currId);
-        if (!edges || edges.length < 3) return true;
-
-        const incoming = Math.atan2(
-            curr[1] - prev[1],
-            curr[0] - prev[0],
-        );
-
-        let bestDot = -Infinity;
-        let takenDot = -Infinity;
-
-        for (const edge of edges) {
-            const to = nodeCoords.get(edge.to);
-            if (!to) continue;
-
-            const angle = Math.atan2(
-                to[1] - curr[1],
-                to[0] - curr[0],
-            );
-
-            const dot = Math.cos(angle - incoming);
-            bestDot = Math.max(bestDot, dot);
-
-            if (to[0] === next[0] && to[1] === next[1]) {
-                takenDot = dot;
-            }
-        }
-
-        return takenDot >= bestDot - 0.15;
-    }
-
-    let activeAngle = 0;
-    let activeSign = 0;
-    let activeIndex = -1;
-    let activeDistance = 0;
-
+    // Identify all turns and forks
     for (let i = 1; i < rawPath.length - 1; i++) {
-        const prev = rawPath[i - 1]!;
-        const curr = rawPath[i]!;
-        const next = rawPath[i + 1]!;
+        const prev = rawPath[i - 1];
+        const curr = rawPath[i];
+        const next = rawPath[i + 1];
 
         const angle = getSignedAngle(prev, curr, next);
         const abs = Math.abs(angle);
-        const sign = Math.sign(angle);
-        const km = stats[i * 2]!;
 
         const currId = pathNodeIds[i];
-        const degree = currId !== undefined
-            ? adjacency.get(currId)?.length ?? 0
-            : 0;
+        const degree = currId !== undefined ? (adjacency.get(currId)?.length ?? 0) : 0;
 
-        const isTopologyTurn =
-            currId !== undefined &&
-            degree >= 3 &&
-            !tookStraightEdge(prev, curr, next, currId);
-
-        const isHardGeometryTurn = abs >= HARD_TURN;
-        const shouldStartTurn = isTopologyTurn || isHardGeometryTurn;
-
-        if (!shouldStartTurn && abs < STRAIGHT_RESET) {
-            if (Math.abs(activeAngle) >= SLIGHT_TURN) {
-                const hard = Math.abs(activeAngle) >= HARD_TURN;
-                const left = activeAngle < 0;
-
-                const type = hard
-                    ? (left ? "left" : "right")
-                    : (left ? "slight-left" : "slight-right");
-
-                const word = type.replace("-", " ");
-
-                const last = instructions[instructions.length - 1];
-                const suppress =
-                    last &&
-                    (last.type === "left" || last.type === "right") &&
-                    type.startsWith("slight") &&
-                    activeDistance - last.distance < POST_TURN_SUPPRESS_KM;
-
-                if (!suppress && (!last || activeDistance - last.distance >= 0.2)) {
-                    instructions.push({
-                        pathIndex: activeIndex,
-                        type,
-                        description: `Turn ${word}`,
-                        distance: activeDistance,
-                    });
-                }
+        if (degree >= 3 && currId !== undefined) {
+            const fork = detectFork(prev, curr, next, currId, adjacency, nodeCoords);
+            if (fork) {
+                maneuvers.push({ kind: "fork", index: i, side: fork });
+                continue;
             }
-
-            activeAngle = 0;
-            activeSign = 0;
-            activeIndex = -1;
-            continue;
         }
 
-        if (activeSign === 0) {
-            activeAngle = angle;
-            activeSign = sign;
-            activeIndex = i;
-            activeDistance = km;
-        } else if (sign === activeSign) {
-            activeAngle += angle;
-        } else {
-            activeAngle = angle;
-            activeSign = sign;
-            activeIndex = i;
-            activeDistance = km;
+        if (abs >= SLIGHT_TURN) {
+            maneuvers.push({ kind: "turn", index: i, angle });
         }
     }
 
-    instructions.push({
-        pathIndex: rawPath.length - 1,
-        type: "destination",
-        description: "Arrived at destination",
-        distance: stats[(rawPath.length - 1) * 2]!,
-    });
+    maneuvers.push({ kind: "destination", index: rawPath.length - 1 });
+
+    // Build instructions with "continue" lookahead
+    const instructions: TurnInstruction[] = [];
+
+    for (let i = 0; i < maneuvers.length; i++) {
+        const m = maneuvers[i];
+        const km = stats[m.index * 2];
+
+        // Insert continue for the stretch before this maneuver
+        if (i > 0) {
+            const prev = maneuvers[i - 1];
+            const startIndex = prev.index;
+            const endIndex = Math.max(m.index - TOLERANCE_INDICES, startIndex + 1);
+            const straightDistance = stats[endIndex * 2] - stats[startIndex * 2];
+
+            if (straightDistance >= CONTINUE_MIN_KM) {
+                instructions.push({
+                    pathIndex: endIndex,
+                    type: "continue",
+                    description: `Continue`,
+                    distance: stats[endIndex * 2],
+                });
+            }
+        }
+
+        // Build maneuver instruction
+        let instr: TurnInstruction | null = null;
+        if (m.kind === "turn") {
+            const type = Math.abs(m.angle) >= HARD_TURN
+                ? m.angle < 0 ? "left" : "right"
+                : m.angle < 0 ? "slight-left" : "slight-right";
+            instr = {
+                pathIndex: m.index,
+                type,
+                description: `Turn ${type.replace("-", " ")}`,
+                distance: km,
+            };
+        } else if (m.kind === "fork") {
+            instr = {
+                pathIndex: m.index,
+                type: m.side === "left" ? "keep-left" : "keep-right",
+                description: m.side === "left" ? "Keep left" : "Keep right",
+                distance: km,
+            };
+        } else if (m.kind === "destination") {
+            instr = {
+                pathIndex: m.index,
+                type: "destination",
+                description: "Arrived at destination",
+                distance: km,
+            };
+        }
+
+        if (instr) instructions.push(instr);
+    }
 
     return instructions;
+}
+
+export function detectFork(
+    prev: [number, number],
+    curr: [number, number],
+    next: [number, number],
+    currId: number,
+    adjacency: Map<number, Edge[]>,
+    nodeCoords: Map<number, [number, number]>
+): "keep-left" | "keep-right" | null {
+    const edges = adjacency.get(currId);
+    if (!edges || edges.length < 3) return null;
+
+    const incomingAngle = Math.atan2(curr[1] - prev[1], curr[0] - prev[0]);
+
+    let bestDot = -Infinity;
+    let chosenDot = -Infinity;
+    let chosenAngle = 0;
+
+    for (const edge of edges) {
+        const toCoord = nodeCoords.get(edge.to);
+        if (!toCoord) continue;
+
+        const angle = Math.atan2(toCoord[1] - curr[1], toCoord[0] - curr[0]);
+        const dot = Math.cos(angle - incomingAngle);
+
+        bestDot = Math.max(bestDot, dot);
+
+        if (toCoord[0] === next[0] && toCoord[1] === next[1]) {
+            chosenDot = dot;
+            chosenAngle = angle - incomingAngle;
+        }
+    }
+
+    if (bestDot - chosenDot < FORK_MIN_DOT_DIFF) return null;
+
+    return chosenAngle < 0 ? "keep-left" : "keep-right";
 }

--- a/app/assets/utils/routing/turnInstructions.ts
+++ b/app/assets/utils/routing/turnInstructions.ts
@@ -7,8 +7,10 @@ export interface TurnInstruction {
     distance: number;
 }
 
-const minTurn = 15;
-const minSlightTurn = 45;
+const HARD_TURN = 45;
+const SLIGHT_TURN = 25;
+const STRAIGHT_RESET = 10;
+const POST_TURN_SUPPRESS_KM = 0.5;
 
 export function generateTurnInstructions(
     rawPath: [number, number][],
@@ -27,69 +29,116 @@ export function generateTurnInstructions(
 
     const instructions: TurnInstruction[] = [];
 
-    const formatCoordKey = (coord: [number, number]) => `${coord[0]},${coord[1]}`;
+    const key = (c: [number, number]) => `${c[0]},${c[1]}`;
+    const coordToNode = new Map<string, number>();
+    for (const [id, coord] of nodeCoords) coordToNode.set(key(coord), id);
 
-    const coordToNodeId = new Map<string, number>();
-    const nodeDegree = new Map<number, number>();
+    function tookStraightEdge(
+        prev: [number, number],
+        curr: [number, number],
+        next: [number, number],
+        currId: number
+    ): boolean {
+        const edges = adjacency.get(currId);
+        if (!edges || edges.length < 3) return true;
 
-    for (const [id, coord] of nodeCoords) {
-        coordToNodeId.set(formatCoordKey(coord), id);
-    }
+        const incoming = Math.atan2(curr[1] - prev[1], curr[0] - prev[0]);
 
-    for (const [from, neighbors] of adjacency) {
-        nodeDegree.set(from, (nodeDegree.get(from) ?? 0) + neighbors.length);
-        for (const edge of neighbors) {
-            nodeDegree.set(edge.to, (nodeDegree.get(edge.to) ?? 0) + 1);
+        let bestDot = -Infinity;
+        let takenDot = -Infinity;
+
+        for (const edge of edges) {
+            const to = nodeCoords.get(edge.to);
+            if (!to) continue;
+
+            const angle = Math.atan2(to[1] - curr[1], to[0] - curr[0]);
+            const dot = Math.cos(angle - incoming);
+
+            bestDot = Math.max(bestDot, dot);
+            if (to[0] === next[0] && to[1] === next[1]) takenDot = dot;
         }
+
+        return takenDot >= bestDot - 0.15;
     }
+
+    let activeAngle = 0;
+    let activeSign = 0;
+    let activeIndex = -1;
+    let activeDistance = 0;
 
     for (let i = 1; i < rawPath.length - 1; i++) {
         const prev = rawPath[i - 1]!;
         const curr = rawPath[i]!;
         const next = rawPath[i + 1]!;
 
-        const signedAngle = getSignedAngle(prev, curr, next);
-        const absAngle = Math.abs(signedAngle);
+        const angle = getSignedAngle(prev, curr, next);
+        const abs = Math.abs(angle);
+        const sign = Math.sign(angle);
+        const km = stats[i * 2]!;
 
-        const currId = coordToNodeId.get(formatCoordKey(curr));
-        const degree = currId !== undefined ? nodeDegree.get(currId) ?? 0 : 0;
-        const isIntersection = degree >= 3;
+        const currId = coordToNode.get(key(curr));
+        const degree = currId !== undefined ? (adjacency.get(currId)?.length ?? 0) : 0;
 
-        const effectiveMinTurn = isIntersection ? minTurn : 60;
+        const isTopologyTurn =
+            currId !== undefined &&
+            degree >= 3 &&
+            !tookStraightEdge(prev, curr, next, currId);
 
-        if (absAngle <= effectiveMinTurn) continue;
+        const isHardGeometryTurn = abs >= HARD_TURN;
+        const shouldStartTurn = isTopologyTurn || isHardGeometryTurn;
 
-        const lastInstruction = instructions[instructions.length - 1];
-        const currentKm = stats[i * 2]!;
+        // Emit accumulated turn if the road is straight-ish
+        if (!shouldStartTurn && abs < STRAIGHT_RESET) {
+            if (Math.abs(activeAngle) >= SLIGHT_TURN) {
+                let type: TurnInstruction['type'];
+                let word: string;
 
-        if (lastInstruction) {
-            const delta = currentKm - lastInstruction.distance;
-            if (delta < 0.2) continue;
+                if (Math.abs(activeAngle) >= HARD_TURN) {
+                    type = activeAngle < 0 ? 'left' : 'right';
+                    word = type;
+                } else {
+                    type = activeAngle < 0 ? 'slight-left' : 'slight-right';
+                    word = type === 'slight-left' ? 'slight left' : 'slight right';
+                }
+
+                const last = instructions[instructions.length - 1];
+                const suppress =
+                    last &&
+                    (last.type === 'left' || last.type === 'right') &&
+                    type.startsWith('slight') &&
+                    activeDistance - last.distance < POST_TURN_SUPPRESS_KM;
+
+                if (!suppress && (!last || activeDistance - last.distance >= 0.2)) {
+                    instructions.push({
+                        pathIndex: activeIndex,
+                        type,
+                        description: `Turn ${word}`,
+                        distance: activeDistance,
+                    });
+                }
+            }
+
+            activeAngle = 0;
+            activeSign = 0;
+            activeIndex = -1;
+            continue;
         }
 
-        let turnType: 'slight-left' | 'left' | 'slight-right' | 'right';
-        let turnWord: string;
-
-        if (signedAngle < -minSlightTurn) {
-            turnType = 'left';
-            turnWord = 'left';
-        } else if (signedAngle < -minTurn) {
-            turnType = 'slight-left';
-            turnWord = 'slight left';
-        } else if (signedAngle > minSlightTurn) {
-            turnType = 'right';
-            turnWord = 'right';
+        // Start a new turn
+        if (activeSign === 0) {
+            activeAngle = angle;
+            activeSign = sign;
+            activeIndex = i;
+            activeDistance = km;
+        } else if (sign === activeSign) {
+            activeAngle += angle;
         } else {
-            turnType = 'slight-right';
-            turnWord = 'slight right';
+            // sign flipped, treat as new maneuver
+            activeAngle = angle;
+            activeSign = sign;
+            activeIndex = i;
+            activeDistance = km;
         }
-
-        instructions.push({
-            pathIndex: i,
-            type: turnType,
-            description: `Turn ${turnWord}`,
-            distance: currentKm,
-        });
     }
 
     instructions.push({

--- a/app/assets/utils/routing/turnInstructions.ts
+++ b/app/assets/utils/routing/turnInstructions.ts
@@ -25,7 +25,7 @@ export function generateTurnInstructions(
     stats: Float32Array,
     pathNodeIds: number[],
     nodeCoords: Map<number, [number, number]>,
-    adjacency: Map<number, Edge[]>,
+    adjacency: Map<number, any[]>,
 ): TurnInstruction[] {
     if (rawPath.length < 2) return [{
         pathIndex: 0,
@@ -35,14 +35,17 @@ export function generateTurnInstructions(
     }];
 
     const maneuvers: Maneuver[] = [];
+    let skipUntil = 0;
 
     // Identify all turns and forks
     for (let i = 1; i < rawPath.length - 1; i++) {
+        if (i <= skipUntil) continue;
+
         const prev = rawPath[i - 1];
         const curr = rawPath[i];
         const next = rawPath[i + 1];
 
-        const angle = getSignedAngle(prev, curr, next);
+        const {angle, endIndex} = detectAngle(rawPath, i);
         const abs = Math.abs(angle);
 
         const currId = pathNodeIds[i];
@@ -52,12 +55,14 @@ export function generateTurnInstructions(
             const fork = detectFork(prev, curr, next, currId, adjacency, nodeCoords);
             if (fork) {
                 maneuvers.push({ kind: "fork", index: i, side: fork });
+                skipUntil = i + TOLERANCE_INDICES;
                 continue;
             }
         }
 
         if (abs >= SLIGHT_TURN) {
             maneuvers.push({ kind: "turn", index: i, angle });
+            skipUntil = endIndex;
         }
     }
 
@@ -156,4 +161,21 @@ export function detectFork(
     if (bestDot - chosenDot < FORK_MIN_DOT_DIFF) return null;
 
     return chosenAngle < 0 ? "keep-left" : "keep-right";
+}
+
+function detectAngle(rawPath: [number, number][], i: number): { angle: number; endIndex: number } {
+    let totalAngle = 0;
+    let j = i;
+
+    while (j < rawPath.length - 1) {
+        const a = getSignedAngle(rawPath[j - 1]!, rawPath[j]!, rawPath[j + 1]!);
+
+        if (Math.sign(a) !== Math.sign(totalAngle || a)) break;
+        if (Math.abs(a) < 5) break;
+
+        totalAngle += a;
+        j++;
+    }
+
+    return { angle: totalAngle, endIndex: j };
 }

--- a/app/assets/utils/routing/turnInstructions.ts
+++ b/app/assets/utils/routing/turnInstructions.ts
@@ -1,8 +1,9 @@
 import { getSignedAngle } from "~/assets/utils/map/maths";
+import type { Edge } from "./graphTypes";
 
 export interface TurnInstruction {
     pathIndex: number;
-    type: 'slight-left' | 'left' | 'slight-right' | 'right' | 'straight' | 'destination';
+    type: "slight-left" | "left" | "slight-right" | "right" | "destination";
     description: string;
     distance: number;
 }
@@ -15,23 +16,20 @@ const POST_TURN_SUPPRESS_KM = 0.5;
 export function generateTurnInstructions(
     rawPath: [number, number][],
     stats: Float32Array,
-    nodeCoords: Map<number, [number, number]>,
-    adjacency: Map<number, { to: number; weight: number; r: number }[]>,
+    pathNodeIds: number[],
+    adjacency: Map<number, Edge[]>,
+    nodeCoords: Map<number, [number, number]>
 ): TurnInstruction[] {
     if (rawPath.length < 3) {
         return [{
             pathIndex: rawPath.length - 1,
-            type: 'destination',
-            description: 'Arrive at destination',
+            type: "destination",
+            description: "Arrive at destination",
             distance: 0,
         }];
     }
 
     const instructions: TurnInstruction[] = [];
-
-    const key = (c: [number, number]) => `${c[0]},${c[1]}`;
-    const coordToNode = new Map<string, number>();
-    for (const [id, coord] of nodeCoords) coordToNode.set(key(coord), id);
 
     function tookStraightEdge(
         prev: [number, number],
@@ -42,7 +40,10 @@ export function generateTurnInstructions(
         const edges = adjacency.get(currId);
         if (!edges || edges.length < 3) return true;
 
-        const incoming = Math.atan2(curr[1] - prev[1], curr[0] - prev[0]);
+        const incoming = Math.atan2(
+            curr[1] - prev[1],
+            curr[0] - prev[0],
+        );
 
         let bestDot = -Infinity;
         let takenDot = -Infinity;
@@ -51,11 +52,17 @@ export function generateTurnInstructions(
             const to = nodeCoords.get(edge.to);
             if (!to) continue;
 
-            const angle = Math.atan2(to[1] - curr[1], to[0] - curr[0]);
-            const dot = Math.cos(angle - incoming);
+            const angle = Math.atan2(
+                to[1] - curr[1],
+                to[0] - curr[0],
+            );
 
+            const dot = Math.cos(angle - incoming);
             bestDot = Math.max(bestDot, dot);
-            if (to[0] === next[0] && to[1] === next[1]) takenDot = dot;
+
+            if (to[0] === next[0] && to[1] === next[1]) {
+                takenDot = dot;
+            }
         }
 
         return takenDot >= bestDot - 0.15;
@@ -76,8 +83,10 @@ export function generateTurnInstructions(
         const sign = Math.sign(angle);
         const km = stats[i * 2]!;
 
-        const currId = coordToNode.get(key(curr));
-        const degree = currId !== undefined ? (adjacency.get(currId)?.length ?? 0) : 0;
+        const currId = pathNodeIds[i];
+        const degree = currId !== undefined
+            ? adjacency.get(currId)?.length ?? 0
+            : 0;
 
         const isTopologyTurn =
             currId !== undefined &&
@@ -87,25 +96,22 @@ export function generateTurnInstructions(
         const isHardGeometryTurn = abs >= HARD_TURN;
         const shouldStartTurn = isTopologyTurn || isHardGeometryTurn;
 
-        // Emit accumulated turn if the road is straight-ish
         if (!shouldStartTurn && abs < STRAIGHT_RESET) {
             if (Math.abs(activeAngle) >= SLIGHT_TURN) {
-                let type: TurnInstruction['type'];
-                let word: string;
+                const hard = Math.abs(activeAngle) >= HARD_TURN;
+                const left = activeAngle < 0;
 
-                if (Math.abs(activeAngle) >= HARD_TURN) {
-                    type = activeAngle < 0 ? 'left' : 'right';
-                    word = type;
-                } else {
-                    type = activeAngle < 0 ? 'slight-left' : 'slight-right';
-                    word = type === 'slight-left' ? 'slight left' : 'slight right';
-                }
+                const type = hard
+                    ? (left ? "left" : "right")
+                    : (left ? "slight-left" : "slight-right");
+
+                const word = type.replace("-", " ");
 
                 const last = instructions[instructions.length - 1];
                 const suppress =
                     last &&
-                    (last.type === 'left' || last.type === 'right') &&
-                    type.startsWith('slight') &&
+                    (last.type === "left" || last.type === "right") &&
+                    type.startsWith("slight") &&
                     activeDistance - last.distance < POST_TURN_SUPPRESS_KM;
 
                 if (!suppress && (!last || activeDistance - last.distance >= 0.2)) {
@@ -124,7 +130,6 @@ export function generateTurnInstructions(
             continue;
         }
 
-        // Start a new turn
         if (activeSign === 0) {
             activeAngle = angle;
             activeSign = sign;
@@ -133,7 +138,6 @@ export function generateTurnInstructions(
         } else if (sign === activeSign) {
             activeAngle += angle;
         } else {
-            // sign flipped, treat as new maneuver
             activeAngle = angle;
             activeSign = sign;
             activeIndex = i;
@@ -143,8 +147,8 @@ export function generateTurnInstructions(
 
     instructions.push({
         pathIndex: rawPath.length - 1,
-        type: 'destination',
-        description: 'Arrived at destination',
+        type: "destination",
+        description: "Arrived at destination",
         distance: stats[(rawPath.length - 1) * 2]!,
     });
 

--- a/app/assets/utils/routing/turnInstructions.ts
+++ b/app/assets/utils/routing/turnInstructions.ts
@@ -1,0 +1,103 @@
+import { getSignedAngle } from "~/assets/utils/map/maths";
+
+export interface TurnInstruction {
+    pathIndex: number;
+    type: 'slight-left' | 'left' | 'slight-right' | 'right' | 'straight' | 'destination';
+    description: string;
+    distance: number;
+}
+
+const minTurn = 15;
+const minSlightTurn = 45;
+
+export function generateTurnInstructions(
+    rawPath: [number, number][],
+    stats: Float32Array,
+    nodeCoords: Map<number, [number, number]>,
+    adjacency: Map<number, { to: number; weight: number; r: number }[]>,
+): TurnInstruction[] {
+    if (rawPath.length < 3) {
+        return [{
+            pathIndex: rawPath.length - 1,
+            type: 'destination',
+            description: 'Arrive at destination',
+            distance: 0,
+        }];
+    }
+
+    const instructions: TurnInstruction[] = [];
+
+    const formatCoordKey = (coord: [number, number]) => `${coord[0]},${coord[1]}`;
+
+    const coordToNodeId = new Map<string, number>();
+    const nodeDegree = new Map<number, number>();
+
+    for (const [id, coord] of nodeCoords) {
+        coordToNodeId.set(formatCoordKey(coord), id);
+    }
+
+    for (const [from, neighbors] of adjacency) {
+        nodeDegree.set(from, (nodeDegree.get(from) ?? 0) + neighbors.length);
+        for (const edge of neighbors) {
+            nodeDegree.set(edge.to, (nodeDegree.get(edge.to) ?? 0) + 1);
+        }
+    }
+
+    for (let i = 1; i < rawPath.length - 1; i++) {
+        const prev = rawPath[i - 1]!;
+        const curr = rawPath[i]!;
+        const next = rawPath[i + 1]!;
+
+        const signedAngle = getSignedAngle(prev, curr, next);
+        const absAngle = Math.abs(signedAngle);
+
+        const currId = coordToNodeId.get(formatCoordKey(curr));
+        const degree = currId !== undefined ? nodeDegree.get(currId) ?? 0 : 0;
+        const isIntersection = degree >= 3;
+
+        const effectiveMinTurn = isIntersection ? minTurn : 60;
+
+        if (absAngle <= effectiveMinTurn) continue;
+
+        const lastInstruction = instructions[instructions.length - 1];
+        const currentKm = stats[i * 2]!;
+
+        if (lastInstruction) {
+            const delta = currentKm - lastInstruction.distance;
+            if (delta < 0.2) continue;
+        }
+
+        let turnType: 'slight-left' | 'left' | 'slight-right' | 'right';
+        let turnWord: string;
+
+        if (signedAngle < -minSlightTurn) {
+            turnType = 'left';
+            turnWord = 'left';
+        } else if (signedAngle < -minTurn) {
+            turnType = 'slight-left';
+            turnWord = 'slight left';
+        } else if (signedAngle > minSlightTurn) {
+            turnType = 'right';
+            turnWord = 'right';
+        } else {
+            turnType = 'slight-right';
+            turnWord = 'slight right';
+        }
+
+        instructions.push({
+            pathIndex: i,
+            type: turnType,
+            description: `Turn ${turnWord}`,
+            distance: currentKm,
+        });
+    }
+
+    instructions.push({
+        pathIndex: rawPath.length - 1,
+        type: 'destination',
+        description: 'Arrived at destination',
+        distance: stats[(rawPath.length - 1) * 2]!,
+    });
+
+    return instructions;
+}

--- a/app/components/map/map.vue
+++ b/app/components/map/map.vue
@@ -6,6 +6,7 @@ import { usePlatform } from "~/composables/Platform";
 import eruda from "eruda";
 import { blendWithBg, lightenColor } from "~/assets/utils/shared/colors";
 import { generateTruckIcon } from "~/assets/utils/map/markers";
+import TurnNavigation from "~/components/navigation/turnNavigation/TurnNavigation.vue";
 
 defineProps<{ goHome: () => void }>();
 
@@ -107,6 +108,8 @@ const {
     getSnappedCoords,
     findBestStartConfiguration,
     worker,
+    turnInstructions,
+    nextTurns,
 } = useRouteController(map, adjacency, nodeCoords);
 
 //
@@ -522,6 +525,11 @@ const toggleSettingsPanel = () => {
                             text="Game Offline"
                         />
                     </div>
+                    <TurnNavigation
+                        v-if="isRouteActive && nextTurns.length > 0"
+                        :next-turns="nextTurns"
+                        class="turn-navigation-overlay"
+                    />
 
                     <Transition name="sheet-slide" @after-leave="onSheetClosed">
                         <SheetSlide
@@ -536,6 +544,14 @@ const toggleSettingsPanel = () => {
                             :route-eta="routeEta"
                             :speed-limit="speedLimit"
                             :truck-speed="truckSpeed"
+                        />
+                    </Transition>
+
+                    <Transition name="fade">
+                        <TurnNavigation
+                            v-if="isRouteActive && nextTurns.length > 0"
+                            :next-turns="nextTurns"
+                            class="turn-navigation-overlay"
                         />
                     </Transition>
                 </div>

--- a/app/components/navigation/sheetSlide.vue
+++ b/app/components/navigation/sheetSlide.vue
@@ -70,7 +70,7 @@ function onToggleSheet() {
                     <Icon name="lets-icons:road-finish-fill" size="22" />
                     <div class="right">
                         <span
-                            >{{ routeDistanceConverted }} {{ distanceUnit }},
+                            >{{ routeDistanceConverted.toFixed(2) }} {{ distanceUnit }},
                         </span>
                         <span>{{ routeEta }}</span>
                     </div>
@@ -84,7 +84,7 @@ function onToggleSheet() {
                     <div class="mini-stats">
                         <span class="eta">{{ routeEta }}</span>
                         <span class="dist"
-                            >({{ routeDistanceConverted }}
+                            >({{ routeDistanceConverted.toFixed(2) }}
                             {{ distanceUnit }})</span
                         >
                     </div>

--- a/app/components/navigation/speedLimit.vue
+++ b/app/components/navigation/speedLimit.vue
@@ -18,11 +18,11 @@ const speedLimitConverted = computed(() => kmToUserUnits(props.speedLimit));
                 v-if="truckSpeed > speedLimit + 5"
                 class="speed-limit-circle-over-limit"
             >
-                <div class="over-limit">{{ truckSpeedConverted }}</div>
+                <div class="over-limit">{{ truckSpeedConverted.toFixed(0) }}</div>
             </div>
         </Transition>
         <div class="speed-limit">
-            {{ speedLimitConverted }}
+            {{ speedLimitConverted.toFixed(0) }}
         </div>
     </div>
 </template>

--- a/app/components/navigation/topBar.vue
+++ b/app/components/navigation/topBar.vue
@@ -21,7 +21,7 @@ const fuelConverted = computed(() => literToUserUnits(props.fuel));
         <div class="truck-info">
             <div class="truck-speed-div">
                 <div class="road-perspective"></div>
-                <p class="truck-speed">{{ truckSpeedConverted }}</p>
+                <p class="truck-speed">{{ truckSpeedConverted.toFixed(0) }}</p>
                 <p class="km-h">{{ speedUnit }}</p>
             </div>
         </div>
@@ -34,8 +34,8 @@ const fuelConverted = computed(() => literToUserUnits(props.fuel));
                         :class="{ 'pulse-red': fuel < 100 }"
                     />
                     <p>
-                        {{ fuelConverted
-                        }}<span class="liters">{{ fuelUnit }}</span>
+                        {{ fuelConverted.toFixed(0) }}
+                        <span class="liters">{{ fuelUnit }}</span>
                     </p>
                 </div>
 

--- a/app/components/navigation/turnNavigation/TurnArrow.vue
+++ b/app/components/navigation/turnNavigation/TurnArrow.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{
+  type: 'straight' | 'slight-left' | 'left' | 'slight-right' | 'right' | 'destination'
+  angle?: number
+}>()
+
+const isDestination = computed(() => props.type === 'destination')
+
+// Generate properly aligned curve
+function generateArrowPath(type: string) {
+  const startX = 16
+  const startY = 28
+  const length = 24
+  const sharpness = 12 // how far the curve bends horizontally
+
+  switch (type) {
+    case 'straight':
+      return `M${startX} ${startY} L${startX} ${startY - length}`
+
+    case 'slight-left':
+      return `M${startX} ${startY} C${startX} ${startY - 8}, ${startX - 6} ${startY - 16}, ${startX - 4} ${startY - length}`
+
+    case 'slight-right':
+      return `M${startX} ${startY} C${startX} ${startY - 8}, ${startX + 6} ${startY - 16}, ${startX + 4} ${startY - length}`
+
+    case 'left':
+      // sharp left: quarter-circle tangent
+      return `M${startX} ${startY} C${startX} ${startY - sharpness}, ${startX - sharpness} ${startY - length + sharpness}, ${startX - sharpness} ${startY - length}`
+
+    case 'right':
+      // sharp right: quarter-circle tangent
+      return `M${startX} ${startY} C${startX} ${startY - sharpness}, ${startX + sharpness} ${startY - length + sharpness}, ${startX + sharpness} ${startY - length}`
+
+    default:
+      return `M${startX} ${startY} L${startX} ${startY - length}`
+  }
+}
+
+const arrowPath = computed(() => {
+  if (isDestination.value) return ''
+  return generateArrowPath(props.type)
+})
+
+const arrowheadSize = computed(() => {
+  switch (props.type) {
+    case 'slight-left':
+    case 'slight-right': return 4
+    case 'left':
+    case 'right': return 6
+    default: return 5
+  }
+})
+</script>
+
+<template>
+  <div class="turn-arrow">
+    <svg v-if="!isDestination" width="32" height="32" viewBox="0 0 32 32">
+      <defs>
+        <marker
+          id="arrowhead"
+          viewBox="0 0 10 10"
+          refX="8"
+          refY="5"
+          :markerWidth="arrowheadSize"
+          :markerHeight="arrowheadSize"
+          orient="auto"
+        >
+          <path d="M0 0 L10 5 L0 10" fill="currentColor"/>
+        </marker>
+      </defs>
+
+      <path
+        :d="arrowPath"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2.2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        marker-end="url(#arrowhead)"
+      />
+    </svg>
+
+    <svg v-else width="32" height="32" viewBox="0 0 32 32">
+      <circle cx="16" cy="16" r="10" fill="none" stroke="currentColor" stroke-width="2.2"/>
+      <path
+        d="M11 16 L14.5 19.5 L21 13"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2.2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  </div>
+</template>
+
+<style scoped>
+.turn-arrow {
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+}
+</style>

--- a/app/components/navigation/turnNavigation/TurnArrow.vue
+++ b/app/components/navigation/turnNavigation/TurnArrow.vue
@@ -4,59 +4,66 @@ import { computed } from 'vue'
 const props = defineProps<{
   type: 'straight' | 'slight-left' | 'left' | 'slight-right' | 'right' | 'destination'
   angle?: number
+  size?: 'large' | 'small'
 }>()
 
 const isDestination = computed(() => props.type === 'destination')
+const isSmall = computed(() => props.size === 'small')
 
-// Generate properly aligned curve
-function generateArrowPath(type: string) {
-  const startX = 16
-  const startY = 28
-  const length = 24
-  const sharpness = 12 // how far the curve bends horizontally
+function generateArrowPath(angle: number, scale = 1) {
+  const startX = 16 * scale
+  const startY = 28 * scale
+  const length = 24 * scale
 
-  switch (type) {
-    case 'straight':
-      return `M${startX} ${startY} L${startX} ${startY - length}`
+  if (angle === 0) return `M${startX} ${startY} L${startX} ${startY - length}`
 
-    case 'slight-left':
-      return `M${startX} ${startY} C${startX} ${startY - 8}, ${startX - 6} ${startY - 16}, ${startX - 4} ${startY - length}`
+  const direction = angle > 0 ? 1 : -1
+  const absAngle = Math.min(Math.abs(angle), 90)
+  const dx = direction * (absAngle / 90) * 16 * scale
+  const dy = length
 
-    case 'slight-right':
-      return `M${startX} ${startY} C${startX} ${startY - 8}, ${startX + 6} ${startY - 16}, ${startX + 4} ${startY - length}`
+  const cp1X = startX
+  const cp1Y = startY - dy * 0.5
+  const cp2X = startX + dx * 0.5
+  const cp2Y = startY - dy * 0.5
+  const endX = startX + dx
+  const endY = startY - dy
 
-    case 'left':
-      // sharp left: quarter-circle tangent
-      return `M${startX} ${startY} C${startX} ${startY - sharpness}, ${startX - sharpness} ${startY - length + sharpness}, ${startX - sharpness} ${startY - length}`
-
-    case 'right':
-      // sharp right: quarter-circle tangent
-      return `M${startX} ${startY} C${startX} ${startY - sharpness}, ${startX + sharpness} ${startY - length + sharpness}, ${startX + sharpness} ${startY - length}`
-
-    default:
-      return `M${startX} ${startY} L${startX} ${startY - length}`
-  }
+  return `M${startX} ${startY} C${cp1X} ${cp1Y}, ${cp2X} ${cp2Y}, ${endX} ${endY}`
 }
 
 const arrowPath = computed(() => {
   if (isDestination.value) return ''
-  return generateArrowPath(props.type)
+
+  let angle = 0
+  switch (props.type) {
+    case 'slight-left': angle = -30; break
+    case 'left': angle = -90; break
+    case 'slight-right': angle = 30; break
+    case 'right': angle = 90; break
+  }
+  if (props.angle !== undefined) angle = props.angle
+
+  return generateArrowPath(angle, isSmall.value ? 0.7 : 1)
 })
 
 const arrowheadSize = computed(() => {
+  const base = isSmall.value ? 3 : 5
   switch (props.type) {
     case 'slight-left':
-    case 'slight-right': return 4
+    case 'slight-right': return base
     case 'left':
-    case 'right': return 6
-    default: return 5
+    case 'right': return base + 2
+    default: return base
   }
 })
+
+const arrowColor = computed(() => isSmall.value ? 'rgba(0,0,0,0.5)' : 'currentColor')
 </script>
 
 <template>
-  <div class="turn-arrow">
-    <svg v-if="!isDestination" width="32" height="32" viewBox="0 0 32 32">
+  <div class="turn-arrow" :class="size">
+    <svg v-if="!isDestination" :width="isSmall ? 22 : 32" :height="isSmall ? 22 : 32" viewBox="0 0 32 32">
       <defs>
         <marker
           id="arrowhead"
@@ -67,14 +74,14 @@ const arrowheadSize = computed(() => {
           :markerHeight="arrowheadSize"
           orient="auto"
         >
-          <path d="M0 0 L10 5 L0 10" fill="currentColor"/>
+          <path d="M0 0 L10 5 L0 10" :fill="arrowColor"/>
         </marker>
       </defs>
 
       <path
         :d="arrowPath"
         fill="none"
-        stroke="currentColor"
+        :stroke="arrowColor"
         stroke-width="2.2"
         stroke-linecap="round"
         stroke-linejoin="round"
@@ -82,12 +89,12 @@ const arrowheadSize = computed(() => {
       />
     </svg>
 
-    <svg v-else width="32" height="32" viewBox="0 0 32 32">
-      <circle cx="16" cy="16" r="10" fill="none" stroke="currentColor" stroke-width="2.2"/>
+    <svg v-else :width="isSmall ? 22 : 32" :height="isSmall ? 22 : 32" viewBox="0 0 32 32">
+      <circle cx="16" cy="16" r="10" fill="none" :stroke="arrowColor" stroke-width="2.2"/>
       <path
         d="M11 16 L14.5 19.5 L21 13"
         fill="none"
-        stroke="currentColor"
+        :stroke="arrowColor"
         stroke-width="2.2"
         stroke-linecap="round"
         stroke-linejoin="round"
@@ -98,8 +105,6 @@ const arrowheadSize = computed(() => {
 
 <style scoped>
 .turn-arrow {
-  width: 32px;
-  height: 32px;
   display: grid;
   place-items: center;
 }

--- a/app/components/navigation/turnNavigation/TurnNavigation.vue
+++ b/app/components/navigation/turnNavigation/TurnNavigation.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import TurnArrow from './TurnArrow.vue'
+import type { TurnInstruction } from '~/assets/utils/routing/turnInstructions'
+
+const { kmToUserUnits, distanceUnit } = useUnitConversion()
+
+const props = defineProps<{
+  nextTurns: { instruction: TurnInstruction; distance: number }[]
+}>()
+
+const currentTurn = computed(() => props.nextTurns[0] ?? null)
+const nextUpcomingTurn = computed(() => props.nextTurns[1] ?? null)
+</script>
+
+<template>
+  <div v-if="currentTurn" class="turn-navigation">
+    <div class="current-instruction">
+      <TurnArrow :type="currentTurn.instruction.type" />
+      <div class="instruction-text">
+        <div class="direction">
+          {{ currentTurn.instruction.description }}
+        </div>
+        <div class="distance">
+          in {{ kmToUserUnits(currentTurn.distance).toFixed(1) }} {{ distanceUnit }}
+        </div>
+      </div>
+    </div>
+
+    <div v-if="nextUpcomingTurn" class="upcoming-instructions">
+      <div class="upcoming-item">
+        <div class="then-label">Then</div>
+        <TurnArrow :type="nextUpcomingTurn.instruction.type" />
+        <span>
+          {{ nextUpcomingTurn.instruction.description.replace('Turn ', '').toLowerCase() }}
+          in {{ kmToUserUnits(nextUpcomingTurn.distance).toFixed(2) }} {{ distanceUnit }}
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+
+
+<style scoped>
+.turn-navigation {
+  background: white;
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  max-width: 400px;
+}
+
+.current-instruction {
+  display: flex;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.instruction-text {
+  margin-left: 12px;
+}
+
+.direction {
+  font-size: 18px;
+  font-weight: 500;
+}
+
+.distance {
+  font-size: 14px;
+  color: #666;
+}
+
+.upcoming-instructions {
+  border-top: 1px solid #eee;
+  padding-top: 12px;
+}
+
+.upcoming-item {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+  font-size: 14px;
+}
+
+.then-label {
+  margin-right: 8px;
+  font-weight: 500;
+  color: #666;
+}
+</style>

--- a/app/components/navigation/turnNavigation/TurnNavigation.vue
+++ b/app/components/navigation/turnNavigation/TurnNavigation.vue
@@ -13,9 +13,13 @@ const nextUpcomingTurn = computed(() => props.nextTurns[1] ?? null)
 </script>
 
 <template>
-  <div v-if="currentTurn" class="turn-navigation">
-    <div class="current-instruction">
-      <TurnArrow :type="currentTurn.instruction.type" />
+  <div v-if="currentTurn" class="turn-navigation current-turn">
+
+    <!-- Current Turn -->
+    <div class="turn-block">
+      <div class="arrow-wrapper">
+        <TurnArrow :type="currentTurn.instruction.type" size="large" />
+      </div>
       <div class="instruction-text">
         <div class="direction">
           {{ currentTurn.instruction.description }}
@@ -26,64 +30,97 @@ const nextUpcomingTurn = computed(() => props.nextTurns[1] ?? null)
       </div>
     </div>
 
-    <div v-if="nextUpcomingTurn" class="upcoming-instructions">
-      <div class="upcoming-item">
-        <div class="then-label">Then</div>
-        <TurnArrow :type="nextUpcomingTurn.instruction.type" />
-        <span>
+    <!-- Divider -->
+    <div class="divider"></div>
+
+    <!-- Upcoming Turn -->
+    <div v-if="nextUpcomingTurn" class="turn-block upcoming-turn">
+      <div class="arrow-wrapper">
+        <TurnArrow :type="nextUpcomingTurn.instruction.type" size="small" />
+      </div>
+      <div class="instruction-text">
+        <div class="upcoming-text">
           {{ nextUpcomingTurn.instruction.description.replace('Turn ', '').toLowerCase() }}
-          in {{ kmToUserUnits(nextUpcomingTurn.distance).toFixed(2) }} {{ distanceUnit }}
-        </span>
+          in {{ kmToUserUnits(nextUpcomingTurn.distance).toFixed(1) }} {{ distanceUnit }}
+        </div>
       </div>
     </div>
+
   </div>
 </template>
 
-
 <style scoped>
+/* Container */
 .turn-navigation {
-  background: white;
-  border-radius: 8px;
-  padding: 16px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  max-width: 400px;
+  max-width: 420px;
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.14);
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
-.current-instruction {
+/* Turn Block Base */
+.turn-block {
   display: flex;
   align-items: center;
-  margin-bottom: 16px;
+  padding: 14px 16px;
 }
 
-.instruction-text {
-  margin-left: 12px;
+/* Current Turn Styles */
+.current-turn {
+  background: #f1f3f4;
 }
 
-.direction {
-  font-size: 18px;
-  font-weight: 500;
+.current-turn .direction {
+  font-size: 22px;
+  font-weight: 600;
 }
 
-.distance {
+.current-turn .distance {
+  font-size: 16px;
+  color: #555;
+  margin-top: 4px;
+}
+
+/* Divider */
+.divider {
+  height: 1px;
+  background: #e0e0e0;
+  margin: 0;
+}
+
+/* Upcoming Turn Styles */
+.upcoming-turn {
+  background: #e6e5e5;
+}
+
+.upcoming-text {
   font-size: 14px;
-  color: #666;
-}
-
-.upcoming-instructions {
-  border-top: 1px solid #eee;
-  padding-top: 12px;
-}
-
-.upcoming-item {
+  color: #777;
   display: flex;
   align-items: center;
-  margin-bottom: 8px;
-  font-size: 14px;
+  line-height: 1.2;
 }
 
-.then-label {
+/* Arrow Wrapper */
+.arrow-wrapper {
+  flex-shrink: 0;
+  width: 60px;
+  display: flex;
+  justify-content: center;
+  margin-right: 12px;
+}
+
+/* Upcoming Turn Arrow Adjustments */
+.upcoming-turn .arrow-wrapper {
+  width: 36px;
   margin-right: 8px;
-  font-weight: 500;
-  color: #666;
+}
+
+/* Ensure arrow and text are perfectly aligned vertically */
+.upcoming-text .turn-arrow {
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 6px;
 }
 </style>

--- a/app/components/navigation/turnNavigation/TurnNavigation.vue
+++ b/app/components/navigation/turnNavigation/TurnNavigation.vue
@@ -25,7 +25,8 @@ const nextUpcomingTurn = computed(() => props.nextTurns[1] ?? null)
           {{ currentTurn.instruction.description }}
         </div>
         <div class="distance">
-          in {{ kmToUserUnits(currentTurn.distance).toFixed(1) }} {{ distanceUnit }}
+          {{ currentTurn.instruction.description.includes("Continue")? "for": "in" }} 
+          {{ kmToUserUnits(currentTurn.distance).toFixed(1) }} {{ distanceUnit }}
         </div>
       </div>
     </div>
@@ -41,7 +42,8 @@ const nextUpcomingTurn = computed(() => props.nextTurns[1] ?? null)
       <div class="instruction-text">
         <div class="upcoming-text">
           {{ nextUpcomingTurn.instruction.description.replace('Turn ', '').toLowerCase() }}
-          in {{ kmToUserUnits(nextUpcomingTurn.distance).toFixed(1) }} {{ distanceUnit }}
+          {{ nextUpcomingTurn.instruction.description.includes("Continue")? "for": "in" }}  
+          {{ kmToUserUnits(nextUpcomingTurn.distance).toFixed(1) }} {{ distanceUnit }}
         </div>
       </div>
     </div>

--- a/app/composables/RouteController.ts
+++ b/app/composables/RouteController.ts
@@ -11,6 +11,7 @@ import {
     deleteMapLibreData,
     setMapLibreData,
 } from "~/assets/utils/map/helpers";
+import { getPathNodeIds } from "~/assets/utils/routing/helpers";
 import { generateTurnInstructions, type TurnInstruction } from "~/assets/utils/routing/turnInstructions";
 
 export const useRouteController = (
@@ -541,12 +542,16 @@ export const useRouteController = (
                 const totalKm = cache[lastIdx]!;
                 const totalHours = cache[lastIdx + 1]!;
 
+                const pathNodeIds = getPathNodeIds(currentRoutePath.value!, nodeCoords);
                 turnInstructions.value = generateTurnInstructions(
-                    result.rawPath,
-                    result.stats,
-                    nodeCoords,
-                    adjacency,
+                    result.rawPath, 
+                    result.stats, 
+                    pathNodeIds, 
+                    adjacency, 
+                    nodeCoords
                 );
+
+                console.log("Turn Instructions:", turnInstructions.value);
                 nextTurnIndex.value = 0;
 
                 drawRouteOnMap(result.displayPath);
@@ -663,9 +668,13 @@ export const useRouteController = (
 
         while (
             nextTurnIndex.value < turnInstructions.value.length &&
-            turnInstructions.value[nextTurnIndex.value].distance - currentKm < 0.05
-        ) {
-            nextTurnIndex.value++;
+            turnInstructions.value[nextTurnIndex.value]!.pathIndex * 2 < currentIdx
+            ) {
+            console.log(
+                `Passed maneuver (idx):`,
+                turnInstructions.value[nextTurnIndex.value]!.pathIndex
+            )
+            nextTurnIndex.value++
         }
 
         nextTurns.value = turnInstructions.value
@@ -674,7 +683,7 @@ export const useRouteController = (
                 instruction: instr,
                 distance: Math.max(instr.distance - currentKm, 0)
             }));
-
+        console.log("currentIdx:", currentIdx,"current Turn:", nextTurns.value[0]!.instruction.pathIndex,"next Turn:", nextTurns.value[1]!.instruction.pathIndex);
         const remKm = totalKm - currentKm;
         const remHours = totalHours - currentHours;
 

--- a/app/composables/RouteController.ts
+++ b/app/composables/RouteController.ts
@@ -542,8 +542,6 @@ export const useRouteController = (
                 const totalHours = cache[lastIdx + 1]!;
                 
                 turnInstructions.value = result.turnInstructions;
-
-                console.log("Turn Instructions:", turnInstructions.value);
                 nextTurnIndex.value = 0;
 
                 drawRouteOnMap(result.displayPath);

--- a/app/composables/RouteController.ts
+++ b/app/composables/RouteController.ts
@@ -550,13 +550,6 @@ export const useRouteController = (
                 nextTurnIndex.value = 0;
 
                 drawRouteOnMap(result.displayPath);
-                turnInstructions.value = generateTurnInstructions(
-                    result.rawPath,
-                    result.stats,
-                    nodeCoords,
-                    adjacency,
-                );
-
                 if (createEndMarker) addDestinationMarker(result.endId);
 
                 routeDistance.value = Math.round(totalKm);

--- a/app/composables/RouteController.ts
+++ b/app/composables/RouteController.ts
@@ -556,7 +556,6 @@ export const useRouteController = (
                     nodeCoords,
                     adjacency,
                 );
-                console.log("Turn Instructions:", turnInstructions.value);
 
                 if (createEndMarker) addDestinationMarker(result.endId);
 

--- a/app/composables/RouteController.ts
+++ b/app/composables/RouteController.ts
@@ -666,14 +666,12 @@ export const useRouteController = (
         const totalKm = cache[lastIdx]!;
         const totalHours = cache[lastIdx + 1]!;
 
-        const currentKm = cache[currentIdx * 2];
+        const currentKm = cache[currentIdx] || 0;
         const currentHours = cache[currentIdx + 1]!;
 
-
-        const MIN_PASS_KM = 0.4; 
         while (
             nextTurnIndex.value < turnInstructions.value.length &&
-            currentKm - turnInstructions.value[nextTurnIndex.value].distance > 0.05
+            turnInstructions.value[nextTurnIndex.value].distance - currentKm < 0.05
         ) {
             nextTurnIndex.value++;
         }
@@ -682,7 +680,7 @@ export const useRouteController = (
             .slice(nextTurnIndex.value, nextTurnIndex.value + 2)
             .map(instr => ({
                 instruction: instr,
-                distance: instr.distance - currentKm
+                distance: Math.max(instr.distance - currentKm, 0)
             }));
 
         const remKm = totalKm - currentKm;

--- a/app/composables/RouteController.ts
+++ b/app/composables/RouteController.ts
@@ -11,8 +11,7 @@ import {
     deleteMapLibreData,
     setMapLibreData,
 } from "~/assets/utils/map/helpers";
-import { getPathNodeIds } from "~/assets/utils/routing/helpers";
-import { generateTurnInstructions, type TurnInstruction } from "~/assets/utils/routing/turnInstructions";
+import type { TurnInstruction } from "~/assets/utils/routing/turnInstructions";
 
 export const useRouteController = (
     map: Ref<maplibregl.Map | null>,
@@ -541,15 +540,8 @@ export const useRouteController = (
                 const lastIdx = (result.rawPath.length - 1) * 2;
                 const totalKm = cache[lastIdx]!;
                 const totalHours = cache[lastIdx + 1]!;
-
-                const pathNodeIds = getPathNodeIds(currentRoutePath.value!, nodeCoords);
-                turnInstructions.value = generateTurnInstructions(
-                    result.rawPath, 
-                    result.stats, 
-                    pathNodeIds, 
-                    adjacency, 
-                    nodeCoords
-                );
+                
+                turnInstructions.value = result.turnInstructions;
 
                 console.log("Turn Instructions:", turnInstructions.value);
                 nextTurnIndex.value = 0;
@@ -679,7 +671,7 @@ export const useRouteController = (
                 instruction: instr,
                 distance: Math.max(instr.distance - currentKm, 0)
             }));
-            
+
         const remKm = totalKm - currentKm;
         const remHours = totalHours - currentHours;
 

--- a/app/composables/RouteController.ts
+++ b/app/composables/RouteController.ts
@@ -11,6 +11,7 @@ import {
     deleteMapLibreData,
     setMapLibreData,
 } from "~/assets/utils/map/helpers";
+import { generateTurnInstructions, type TurnInstruction } from "~/assets/utils/routing/turnInstructions";
 
 export const useRouteController = (
     map: Ref<maplibregl.Map | null>,
@@ -21,6 +22,7 @@ export const useRouteController = (
     const { getClosestNodes } = useGraphSystem();
     const { settings, activeSettings, updateGlobal, updateProfile } =
         useSettings();
+
 
     const currentRoutePath = shallowRef<[number, number][] | null>(null);
     const routeStatsCache = shallowRef<Float32Array | null>(null);
@@ -45,6 +47,10 @@ export const useRouteController = (
 
     const currentRouteIndex = ref(0);
     const isWorkerReady = ref(false);
+
+    const turnInstructions = shallowRef<TurnInstruction[]>([]);
+    const nextTurns = shallowRef<{ instruction: TurnInstruction; distance: number }[]>([]);
+    const nextTurnIndex = ref(0);
 
     watch(
         () => activeSettings.value.themeColor,
@@ -535,7 +541,23 @@ export const useRouteController = (
                 const totalKm = cache[lastIdx]!;
                 const totalHours = cache[lastIdx + 1]!;
 
+                turnInstructions.value = generateTurnInstructions(
+                    result.rawPath,
+                    result.stats,
+                    nodeCoords,
+                    adjacency,
+                );
+                nextTurnIndex.value = 0;
+
                 drawRouteOnMap(result.displayPath);
+                turnInstructions.value = generateTurnInstructions(
+                    result.rawPath,
+                    result.stats,
+                    nodeCoords,
+                    adjacency,
+                );
+                console.log("Turn Instructions:", turnInstructions.value);
+
                 if (createEndMarker) addDestinationMarker(result.endId);
 
                 routeDistance.value = Math.round(totalKm);
@@ -644,8 +666,24 @@ export const useRouteController = (
         const totalKm = cache[lastIdx]!;
         const totalHours = cache[lastIdx + 1]!;
 
-        const currentKm = cache[currentIdx]!;
+        const currentKm = cache[currentIdx * 2];
         const currentHours = cache[currentIdx + 1]!;
+
+
+        const MIN_PASS_KM = 0.4; 
+        while (
+            nextTurnIndex.value < turnInstructions.value.length &&
+            currentKm - turnInstructions.value[nextTurnIndex.value].distance > 0.05
+        ) {
+            nextTurnIndex.value++;
+        }
+
+        nextTurns.value = turnInstructions.value
+            .slice(nextTurnIndex.value, nextTurnIndex.value + 2)
+            .map(instr => ({
+                instruction: instr,
+                distance: instr.distance - currentKm
+            }));
 
         const remKm = totalKm - currentKm;
         const remHours = totalHours - currentHours;
@@ -672,6 +710,7 @@ export const useRouteController = (
         currentRoutePath.value = null;
         savedDestination.value = null;
         isYardStart.value = false;
+        turnInstructions.value = [];
         updateProfile("lastDestination", null);
     }
 
@@ -693,5 +732,7 @@ export const useRouteController = (
         updateRouteProgress,
         getSnappedCoords,
         clearRouteState,
+        turnInstructions,
+        nextTurns,
     };
 };

--- a/app/composables/RouteController.ts
+++ b/app/composables/RouteController.ts
@@ -670,10 +670,6 @@ export const useRouteController = (
             nextTurnIndex.value < turnInstructions.value.length &&
             turnInstructions.value[nextTurnIndex.value]!.pathIndex * 2 < currentIdx
             ) {
-            console.log(
-                `Passed maneuver (idx):`,
-                turnInstructions.value[nextTurnIndex.value]!.pathIndex
-            )
             nextTurnIndex.value++
         }
 
@@ -683,7 +679,7 @@ export const useRouteController = (
                 instruction: instr,
                 distance: Math.max(instr.distance - currentKm, 0)
             }));
-        console.log("currentIdx:", currentIdx,"current Turn:", nextTurns.value[0]!.instruction.pathIndex,"next Turn:", nextTurns.value[1]!.instruction.pathIndex);
+            
         const remKm = totalKm - currentKm;
         const remHours = totalHours - currentHours;
 

--- a/app/composables/UnitConversion.ts
+++ b/app/composables/UnitConversion.ts
@@ -5,14 +5,14 @@ export const useUnitConversion = () => {
         if (value == null) return 0;
         return activeSettings.value.units === "metric"
             ? value
-            : Math.round(value * 0.621371);
+            : value * 0.621371;
     };
 
     const literToUserUnits = (value: number | null | undefined) => {
         if (value == null) return 0;
         return activeSettings.value.units === "metric"
             ? value
-            : Math.round(value * 0.264172);
+            : value * 0.264172;
     };
 
     const speedUnit = computed(() =>

--- a/app/workers/route.worker.ts
+++ b/app/workers/route.worker.ts
@@ -67,9 +67,17 @@ self.onmessage = async (e: MessageEvent) => {
 
         if (result && result.path) {
             let fullPath = [...result.path];
+            let turnInstructions= [...result.turnInstructions];
 
             if (projectedStartCoords) {
                 fullPath = [projectedStartCoords, ...fullPath];
+
+                turnInstructions = turnInstructions.map((t) => ({
+                    ...t,
+                    pathIndex: t.type === "destination"
+                        ? fullPath.length - 1
+                        : t.pathIndex + 1,
+                }));
             }
 
             let displayPath = mergeClosePoints(fullPath, 600);
@@ -84,6 +92,11 @@ self.onmessage = async (e: MessageEvent) => {
                 avgSpeed,
             );
 
+            turnInstructions = turnInstructions.map((t) => ({
+                ...t,
+                distance: statsCache[t.pathIndex * 2] ?? 0,
+            }));
+
             self.postMessage(
                 {
                     type: "RESULT",
@@ -92,6 +105,7 @@ self.onmessage = async (e: MessageEvent) => {
                         rawPath: fullPath,
                         displayPath: displayPath,
                         stats: statsCache,
+                        turnInstructions: turnInstructions,
                     },
                 },
                 [statsCache.buffer],

--- a/app/workers/route.worker.ts
+++ b/app/workers/route.worker.ts
@@ -8,6 +8,7 @@ import {
     smoothPath,
     type SimpleCityNode,
 } from "~/assets/utils/routing/algorithm";
+import { cleanInstructions } from "~/assets/utils/routing/turnInstructions";
 
 let cityNodes: SimpleCityNode[] | null = null;
 
@@ -72,12 +73,8 @@ self.onmessage = async (e: MessageEvent) => {
             if (projectedStartCoords) {
                 fullPath = [projectedStartCoords, ...fullPath];
 
-                turnInstructions = turnInstructions.map((t) => ({
-                    ...t,
-                    pathIndex: t.type === "destination"
-                        ? fullPath.length - 1
-                        : t.pathIndex + 1,
-                }));
+                const dest = turnInstructions[turnInstructions.length - 1]!;
+                dest.pathIndex = fullPath.length - 1;
             }
 
             let displayPath = mergeClosePoints(fullPath, 600);
@@ -96,6 +93,8 @@ self.onmessage = async (e: MessageEvent) => {
                 ...t,
                 distance: statsCache[t.pathIndex * 2] ?? 0,
             }));
+            
+            turnInstructions = cleanInstructions(turnInstructions);
 
             self.postMessage(
                 {


### PR DESCRIPTION
Added the ability to show turn based navigation. This is hard WIP, but would love some feedback. Also full disclosure, I did use ai specifically to better find turns while reducing false positives and to better generate arrow svgs.

Changes:

When route is generated, it also generates turnInsturctions. Moved to worker so we only evaluate route once. 
During route update, it finds the next two turns and returns them as well.
next turns are passed to a turn navigation component that renders turn arrow, turn instruction, and the same for the next turn.
Like i mentioned HARD WIP. Will also clean up css and move to files before merge.