### PR TITLE
Fix incorrect Czech translation

### DIFF
--- a/app/locales/cs.json
+++ b/app/locales/cs.json
@@ -97,7 +97,7 @@
     },
     "languages": {
         "czech": "Čeština",
-        "dutch": "Holandčina",
+        "dutch": "Nizozemština",
         "english": "Angličtina",
         "german": "Němčina",
         "slovak": "Slovenština"


### PR DESCRIPTION
Fixed mistake: The Czech translation of "Dutch" was in Slovak.