### PR TITLE
Add support for TruckTel

### DIFF
--- a/.github/workflows/build-trucktel.yaml
+++ b/.github/workflows/build-trucktel.yaml
@@ -1,0 +1,56 @@
+name: Build TruckTel app
+
+on:
+    workflow_dispatch:
+
+jobs:
+    # ---------------------------------------------------------
+    # BUILD TRUCKTEL PLUGIN
+    # ---------------------------------------------------------
+    build-trucktel:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout Code
+              uses: actions/checkout@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "22"
+                  cache: "npm"
+
+            - name: Install Root Dependencies
+              run: npm install
+
+            - name: Get latest TruckTel release information
+              id: trucktel
+              uses: pozetroninc/github-action-get-latest-release@master
+              with:
+                repository: jvanstraten/TruckTel
+
+            - name: Download TruckTel
+              run: |
+                  mkdir -p gamebindir/plugins
+                  wget https://github.com/jvanstraten/TruckTel/releases/download/${{ steps.trucktel.outputs.release }}/trucktel.zip
+                  7z x -ogamebindir/plugins trucktel.zip
+
+            - name: Remove TruckTel example apps
+              run: |
+                  rm -rf gamebindir/plugins/trucktel/*/
+
+            - name: Build Nuxt Web App
+              run: |
+                  npx nuxi generate
+
+            - name: Generate TruckTel app
+              run: |
+                  mkdir -p gamebindir/plugins/trucktel/trucknav/www
+                  cp trucktel/config.yaml gamebindir/plugins/trucktel/trucknav
+                  cp -r .output/public/* gamebindir/plugins/trucktel/trucknav/www
+                  cp trucktel/README.txt gamebindir
+
+            - name: Upload TruckTel app to GitHub
+              uses: actions/upload-artifact@v4
+              with:
+                  name: TruckNav-On-TruckTel
+                  path: gamebindir

--- a/app/assets/scss/scoped/navigation/topBar.scss
+++ b/app/assets/scss/scoped/navigation/topBar.scss
@@ -119,15 +119,22 @@
     }
 }
 
-.disconnected-div {
+.game-status-div {
     display: flex;
     gap: 0.8rem;
     align-items: center;
     justify-content: center;
 
-    .disconnected-message {
+    .game-status-message {
         font-size: 1.6rem;
         font-weight: 600;
+    }
+
+    .paused-icon {
+        background-color: $white-font-text;
+        opacity: 0.9;
+        width: 20px;
+        height: 20px;
     }
 
     .disconnected-icon {

--- a/app/assets/utils/telemetry/helpers.ts
+++ b/app/assets/utils/telemetry/helpers.ts
@@ -1,16 +1,16 @@
 import { convertAtsToGeo, convertEts2ToGeo } from "../map/converters";
 import { getBearing } from "../map/maths";
-import type { GameType, TelemetryPacket } from "~/types";
+import type { GameType, CommonTelemetryData } from "~/types";
 
 export function getTruckState(
-    data: TelemetryPacket,
+    data: CommonTelemetryData,
     lastPosition: [number, number] | null,
     selectedGame: GameType,
     currentHeadingOffset: number,
     speedSamples: number[],
     maxSamples: number,
 ) {
-    const { x, z } = data.truck.current.position;
+    const { x, z } = data.nav.position;
     let truckCoords: [number, number];
 
     if (Math.abs(x) < 0.001 && Math.abs(z) < 0.001) {
@@ -24,12 +24,12 @@ export function getTruckState(
 
     const truckSpeed = Math.max(
         0,
-        Math.floor(data.truck.current.dashboard.speedKph),
+        Math.floor(data.nav.speedKph),
     );
 
     const avgSpeed = updateMovingAverage(truckSpeed, speedSamples, maxSamples);
 
-    const rawGameHeading = data.truck.current.heading;
+    const rawGameHeading = data.nav.rawGameHeading;
     const { heading, newOffset } = getCorrectHeading(
         rawGameHeading,
         truckSpeed,
@@ -47,32 +47,11 @@ export function getTruckState(
     };
 }
 
-export function getGameState(data: TelemetryPacket) {
-    const name = data.game.toLowerCase();
-    const gameConnected = name === "ets2" || name === "ats";
+export function getNavigationState(data: CommonTelemetryData) {
+    const fuel = parseInt(data.truck.fuel.toFixed(1));
+    const speedLimit = Math.max(0, Math.round(data.nav.speedLimitKph));
 
-    const scale = data.common.mapScale;
-
-    const hasInGameMarker =
-        data.navigation.distance > 100 && data.job.income === 0;
-
-    const { formatted, raw } = convertTelemtryTime(data.common.gameTime);
-    const day = raw.toUTCString().slice(0, 3);
-    const gameTime = `${day} ${formatted}`;
-
-    return {
-        gameConnected,
-        hasInGameMarker,
-        gameTime,
-        scale,
-    };
-}
-
-export function getNavigationState(data: TelemetryPacket) {
-    const fuel = parseInt(data.truck.current.dashboard.fuelAmount.toFixed(1));
-    const speedLimit = Math.max(0, Math.round(data.navigation.speedLimitKph));
-
-    const totalMinutes = data.common.nextRestStopMinutes;
+    const totalMinutes = data.nextRestStopMinutes;
     const hours = Math.max(0, Math.floor(totalMinutes / 60));
     const mins = Math.max(0, totalMinutes % 60);
 
@@ -83,42 +62,34 @@ export function getNavigationState(data: TelemetryPacket) {
     return { fuel, speedLimit, restStoptime, restStopMinutes: totalMinutes };
 }
 
-export function getJobState(data: TelemetryPacket, selectedGame: GameType) {
+export function getJobState(data: CommonTelemetryData, selectedGame: GameType) {
     let companyTarget = "";
     let cityTarget = "";
     let trailerCoords: [number, number] = [0, 0];
 
-    const hasActiveJob = data.specialEvents.onJob;
+    const hasActiveJob = data.job.active;
 
-    const destinationCity = data.job.cityDestinationId;
-    const destinationCompany = data.job.companyDestinationId;
+    const destinationCity = data.job.destination.cityId;
+    const destinationCompany = data.job.destination.companyId;
 
-    const jobType = data.job.jobType;
+    const jobType = data.job.type;
 
-    const sourceCity = data.job.citySourceId;
-    const sourceCompany = data.job.companySourceId;
+    const sourceCity = data.job.origin.cityId;
+    const sourceCompany = data.job.origin.companyId;
 
-    if (data.trailers[0]) {
-        const isTrailerAvailable =
-            data.trailers[0].position.y !== 0 &&
-            data.trailers[0].position.x !== 0;
+    const isTrailerAvailable = data.truck.trailerAvailable;
+    const isTrailerAttached = data.truck.trailerAttached;
 
-        const isTrailerAttached = data.trailers[0]?.attached;
+    if (jobType === "external_contracts" || jobType === "external_market") {
+        companyTarget =
+            isTrailerAvailable && !isTrailerAttached
+                ? sourceCompany
+                : destinationCompany;
 
-        if (jobType === "external_contracts" || jobType === "external_market") {
-            companyTarget =
-                isTrailerAvailable && !isTrailerAttached
-                    ? sourceCompany
-                    : destinationCompany;
-
-            cityTarget =
-                isTrailerAvailable && !isTrailerAttached
-                    ? sourceCity
-                    : destinationCity;
-        } else {
-            companyTarget = destinationCompany;
-            cityTarget = destinationCity;
-        }
+        cityTarget =
+            isTrailerAvailable && !isTrailerAttached
+                ? sourceCity
+                : destinationCity;
     } else {
         companyTarget = destinationCompany;
         cityTarget = destinationCity;
@@ -195,17 +166,6 @@ function getCorrectHeading(
     finalHeading = ((finalHeading % 360) + 360) % 360;
 
     return { heading: finalHeading, newOffset: internalOffset };
-}
-
-function convertTelemtryTime(time: string) {
-    const date = new Date(time);
-    return {
-        formatted: `${date.getUTCHours().toString().padStart(2, "0")}:${date
-            .getUTCMinutes()
-            .toString()
-            .padStart(2, "0")}`,
-        raw: date,
-    };
 }
 
 function updateMovingAverage(

--- a/app/components/layouts/chooseGame.vue
+++ b/app/components/layouts/chooseGame.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+import {Capacitor} from "@capacitor/core";
+
 const props = defineProps<{
     launchMap: () => void;
     goToDesktopIndex: () => void;
@@ -11,10 +13,45 @@ const handleStart = () => {
     commitSelection();
     props.launchMap();
 };
+
+const manualSelection = ref(false);
+
+async function autoSelectGame(): Promise<"ets2" | "ats" | "unknown"> {
+    if (Capacitor.isNativePlatform()) return "unknown";
+    const url = "/api/rest/single/game/id";
+    try {
+        const response = await fetch(url, { signal: AbortSignal.timeout(500) });
+        if (!response.ok) return "unknown";
+        const result = await response.text();
+        if (result === '"eut2"') {
+            return "ets2";
+        } else if (result === '"ats"') {
+            return "ats";
+        }
+        return "unknown";
+    } catch (e) {
+        console.error(`unexpected error trying to auto-detect game: ${e}`);
+        return "unknown";
+    }
+}
+
+onMounted(async () => {
+    console.log("Trying to auto-detect game using TruckTel API...");
+    const result = await autoSelectGame();
+    if (result == "unknown") {
+        console.log("Auto-detection failed");
+        manualSelection.value = true;
+    } else {
+        console.log(`Detected ${result.toUpperCase()}`);
+        selectedGame.value = result;
+        handleStart();
+    }
+});
+
 </script>
 
 <template>
-    <div class="choose-game-section">
+    <div v-show="manualSelection" class="choose-game-section">
         <div class="top-tagline">
             <button
                 v-show="isElectron"

--- a/app/components/map/map.vue
+++ b/app/components/map/map.vue
@@ -36,6 +36,7 @@ const {
     stopTelemetry,
     gameTime,
     gameConnected,
+    simDataValid,
     truckCoords,
     truckSpeed,
     speedLimit,
@@ -463,6 +464,7 @@ const onCancelRoute = () => {
                         v-show="settings.activeUiComponents.includes('topBar')"
                         :fuel="fuel"
                         :game-connected="gameConnected"
+                        :sim-data-valid="simDataValid"
                         :game-time="gameTime"
                         :rest-stop-minutes="restStopMinutes"
                         :rest-stop-time="restStoptime"

--- a/app/components/navigation/topBar.vue
+++ b/app/components/navigation/topBar.vue
@@ -2,6 +2,7 @@
 const props = defineProps<{
     truckSpeed: number;
     gameConnected: boolean;
+    simDataValid: boolean;
     fuel: number;
     restStopMinutes: number;
     restStopTime: string;
@@ -32,7 +33,7 @@ const fuelConverted = computed(() => literToUserUnits(props.fuel));
             </div>
         </div>
 
-        <div v-if="gameConnected" class="gas-sleep-time">
+        <div v-if="simDataValid" class="gas-sleep-time">
             <div class="gas-sleep">
                 <div
                     v-show="settings.activeUiComponents.includes('fuel')"
@@ -71,9 +72,14 @@ const fuelConverted = computed(() => literToUserUnits(props.fuel));
             </p>
         </div>
 
-        <div v-else class="disconnected-div">
-            <p class="disconnected-message">{{ t("common.gameOffline") }}</p>
+        <div v-else-if="!gameConnected" class="game-status-div">
+            <p class="game-status-message">{{ t("common.gameOffline") }}</p>
             <Icon name="lucide:wifi-off" class="disconnected-icon" />
+        </div>
+
+        <div v-else class="game-status-div">
+            <p class="game-status-message">{{ t("common.gamePaused") }}</p>
+            <Icon name="lucide:pause" class="paused-icon" />
         </div>
     </div>
 </template>

--- a/app/composables/EtsTelemetry.ts
+++ b/app/composables/EtsTelemetry.ts
@@ -1,6 +1,5 @@
 import { Capacitor } from "@capacitor/core";
 import {
-    getGameState,
     getJobState,
     getNavigationState,
     getTruckState,
@@ -12,6 +11,8 @@ import type {
     JobState,
     TelemetryUpdate,
     TelemetryPacket,
+    TruckTelPacket,
+    CommonTelemetryData,
 } from "~/types";
 
 const truckState = reactive<TruckState>({
@@ -24,6 +25,7 @@ const truckState = reactive<TruckState>({
 const gameState = reactive<GameState>({
     gameTime: "",
     gameConnected: false,
+    simDataValid: false,
     hasInGameMarker: false,
     scale: 0,
 });
@@ -86,27 +88,41 @@ export function useEtsTelemetry() {
     let speedSamples: number[] = [];
     const maxSamples = 120;
 
+    let isTruckTel: boolean = false;
+    let truckTelCurrentState: TruckTelPacket = {};
+    let truckTelLastKnownState: TruckTelPacket = {};
+
     function startTelemetry(onUpdate?: (data: TelemetryUpdate) => void) {
         if (socket) return;
 
         const ip = isCapacitor
             ? settings.value.savedIP
             : window.location.hostname;
-        const url = `ws://${ip}:30001`;
+        const path = isTruckTel ? "/api/ws/delta/nav?throttle=100" : "";
+        const url = `ws://${ip}:30001${path}`;
 
         socket = new WebSocket(url);
 
         socket.onopen = () => {
-            console.log("Connected to Bridge");
+            if (isTruckTel) {
+                console.log("Connected to TruckTel");
+            } else {
+                console.log("Connected to Bridge");
+            }
         };
 
         socket.onmessage = (event) => {
             try {
                 const rawData = JSON.parse(event.data);
 
-                const data = rawData as TelemetryPacket;
+                let data;
+                if (isTruckTel) {
+                    data = convertTruckTelData(rawData);
+                } else {
+                    data = convertScsSdkPluginData(rawData);
+                }
 
-                if (data.game.toLowerCase() !== settings.value.selectedGame) {
+                if (data.connection.game.toLowerCase() !== settings.value.selectedGame) {
                     resetDataOnDisconnected(onUpdate);
                     return;
                 }
@@ -119,9 +135,21 @@ export function useEtsTelemetry() {
             }
         };
 
-        socket.onclose = () => {
+        socket.onclose = (e: CloseEvent) => {
             socket = null;
+            truckTelCurrentState = {};
+            truckTelLastKnownState = {};
             resetDataOnDisconnected(onUpdate);
+
+            // TruckTel immediately closes websockets with
+            // "1000 invalid endpoint" if the URL path is not a websocket API.
+            // Detect that and immediately reopen in TruckTel mode.
+            if (e.code == 1000 && e.reason.trim().toLowerCase() == "invalid endpoint") {
+                console.log("Detected TruckTel connection");
+                isTruckTel = true;
+                startTelemetry(onUpdate);
+                return;
+            }
             setTimeout(() => startTelemetry(onUpdate), 3000);
         };
     }
@@ -133,18 +161,178 @@ export function useEtsTelemetry() {
         }
     }
 
+    function convertScsSdkPluginData(rawData: object): CommonTelemetryData {
+        const data = rawData as TelemetryPacket;
+
+        const name = data.game.toLowerCase();
+        const gameConnected = name === "ets2" || name === "ats";
+
+        const date = new Date(data.common.gameTime);
+        const formatted = `${date.getUTCHours().toString().padStart(2, "0")}:${date
+                .getUTCMinutes()
+                .toString()
+                .padStart(2, "0")}`;
+        const day = date.toUTCString().slice(0, 3);
+        const gameTimeFormatted = `${day} ${formatted}`;
+
+        const trailerAvailable =
+            data.trailers[0] &&
+            data.trailers[0].position.y !== 0 &&
+            data.trailers[0].position.x !== 0;
+
+        const trailerAttached = data.trailers[0]?.attached;
+
+        return {
+            connection: {
+                connectedToBridge: gameConnected,
+                simDataValid: gameConnected,
+                game: data.game,
+            },
+            nav: {
+                position: data.truck.current.position,
+                speedKph: data.truck.current.dashboard.speedKph,
+                rawGameHeading: data.truck.current.heading,
+                mapScale: data.common.mapScale,
+                speedLimitKph: data.navigation.speedLimitKph,
+                inGameNavDistance: data.navigation.distance,
+            },
+            truck: {
+                brand: data.truck.constants?.brand,
+                name: data.truck.constants?.name,
+                trailerAvailable: trailerAvailable ?? false,
+                trailerAttached: trailerAttached ?? false,
+                fuel: data.truck.current.dashboard.fuelAmount,
+            },
+            job: {
+                active: data.specialEvents.onJob,
+                type: data.job.jobType,
+                origin: {
+                    companyName: data.job.companySource,
+                    companyId: data.job.companySourceId,
+                    cityName: data.job.citySource,
+                    cityId: data.job.citySourceId,
+                },
+                destination: {
+                    companyName: data.job.companyDestination,
+                    companyId: data.job.companyDestinationId,
+                    cityName: data.job.cityDestination,
+                    cityId: data.job.cityDestinationId,
+                },
+                cargo: data.job.cargo?.name,
+                income: data.job.income,
+            },
+            nextRestStopMinutes: data.common.nextRestStopMinutes,
+            gameTimeFormatted: gameTimeFormatted,
+        };
+    }
+
+    function convertTruckTelData(rawData: object): CommonTelemetryData {
+        // After the first packet, TruckTel only sends keys that have changed.
+        Object.assign(truckTelCurrentState, rawData);
+
+        // TruckTel sends null for keys that the game has invalidated, which
+        // happens  in particular for simulation state when the game has
+        // paused. We prefer to use the latest known data in most cases,
+        // though.
+        for (const [key, value] of Object.entries(rawData)) {
+            if (value !== null) {
+                Object.assign(truckTelLastKnownState, {[key]: value});
+            }
+        }
+
+        const simDataValid = truckTelLastKnownState.speedKph !== null && truckTelLastKnownState.speedKph !== undefined;
+
+        // Shorthands.
+        const cur = truckTelCurrentState;
+        const data = truckTelLastKnownState;
+
+        // Convert from internal SCS API game ID to normal abbreviations.
+        let game = "unknown";
+        if (data.game === "eut2") {
+            game = "ETS2";
+        } else if (data.game === "ats") {
+            game = "ATS";
+        }
+
+        // Convert game time.
+        const timestamp = data.timestamp ?? 0;
+        const min = timestamp % 60;
+        const hrs = Math.floor(timestamp / 60) % 24;
+        const day = Math.floor(timestamp / 60 / 24) % 7;
+        const minStr = min.toString().padStart(2, "0");
+        const hrsStr = hrs.toString().padStart(2, "0");
+        const dayStr = {
+            0: "Mon",
+            1: "Tue",
+            2: "Wed",
+            3: "Thu",
+            4: "Fri",
+            5: "Sat",
+            6: "Sun",
+        }[day];
+        const gameTimeFormatted = `${dayStr} ${hrsStr}:${minStr}`;
+
+        return {
+            connection: {
+                connectedToBridge: true, // there is no bridge
+                simDataValid: simDataValid,
+                game,
+            },
+            nav: {
+                position: {
+                    x: data.posX ?? 0,
+                    y: data.posY ?? 0,
+                    z: data.posZ ?? 0,
+                },
+                speedKph: data.speedKph ?? 0,
+                rawGameHeading: data.rawHeading ?? 0,
+                mapScale: data.scale ?? 1,
+                speedLimitKph: data.speedLimitKph ?? 0,
+                inGameNavDistance: data.navDist ?? 0,
+            },
+            truck: {
+                brand: data.truckBrand ?? "",
+                name: data.truckName ?? "",
+                trailerAvailable: cur.trailerAttached !== null,
+                trailerAttached: data.trailerAttached ?? false,
+                fuel: data.fuel ?? 0,
+            },
+            job: {
+                active: !!data.jobType,
+                type: data.jobType ?? "",
+                origin: {
+                    companyName: data.origCompName ?? "",
+                    companyId: data.origCompId ?? "",
+                    cityName: data.origCityName ?? "",
+                    cityId: data.origCityId ?? "",
+                },
+                destination: {
+                    companyName: data.destCompName ?? "",
+                    companyId: data.destCompId ?? "",
+                    cityName: data.destCityName ?? "",
+                    cityId: data.destCityId ?? "",
+                },
+                cargo: data.cargoName ?? "",
+                income: data.income ?? 0,
+            },
+            nextRestStopMinutes: data.restRemain ?? 0,
+            gameTimeFormatted,
+        };
+    }
+
     function processData(
-        data: TelemetryPacket,
+        data: CommonTelemetryData,
         onUpdate?: (data: TelemetryUpdate) => void,
     ) {
-        const { gameConnected, hasInGameMarker, gameTime, scale } =
-            getGameState(data);
+        const hasInGameMarker =
+            data.nav.inGameNavDistance > 100 && data.job.income === 0;
 
         Object.assign(gameState, {
-            gameTime: gameTime,
-            gameConnected: gameConnected,
+            gameTime: data.gameTimeFormatted,
+            gameConnected: data.connection.connectedToBridge,
+            simDataValid: data.connection.simDataValid,
             hasInGameMarker: hasInGameMarker,
-            scale: scale,
+            scale: data.nav.mapScale,
         });
 
         const {
@@ -195,15 +383,14 @@ export function useEtsTelemetry() {
         });
 
         sendDiscordRpcState({
-            game: data.game,
-            connected: gameConnected,
+            game: data.connection.game,
+            connected: data.connection.connectedToBridge,
             hasActiveJob,
-            sourceCity: data.job.citySource || data.job.citySourceId,
-            destinationCity:
-                data.job.cityDestination || data.job.cityDestinationId,
-            cargoName: data.job.cargo?.name,
-            truckBrand: data.truck.constants?.brand,
-            truckName: data.truck.constants?.name,
+            sourceCity: data.job.origin.cityName ?? data.job.origin.cityId,
+            destinationCity: data.job.destination.cityName ?? data.job.destination.cityId,
+            cargoName: data.job.cargo,
+            truckBrand: data.truck.brand,
+            truckName: data.truck.name,
         });
 
         if (onUpdate) {
@@ -215,6 +402,7 @@ export function useEtsTelemetry() {
             });
         }
     }
+
 
     function resetDataOnDisconnected(
         onUpdate?: (data: TelemetryUpdate) => void,

--- a/app/locales/de.json
+++ b/app/locales/de.json
@@ -10,6 +10,7 @@
         "distance": "Distanz",
         "estimatedTime": "Geschätzte Zeit",
         "gameOffline": "Spiel offline",
+        "gamePaused": "Spiel pausiert",
         "hide": "Ausblenden",
         "loadingRouteData": "Routendaten werden geladen...",
         "missing": "Fehlt",

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -10,6 +10,7 @@
         "distance": "Distance",
         "estimatedTime": "Estimated Time",
         "gameOffline": "Game Offline",
+        "gamePaused": "Game Paused",
         "hide": "Hide",
         "loadingRouteData": "Loading Route Data...",
         "missing": "Missing",

--- a/app/locales/nl.json
+++ b/app/locales/nl.json
@@ -10,6 +10,7 @@
         "distance": "Afstand",
         "estimatedTime": "Geschatte tijd",
         "gameOffline": "Game offline",
+        "gamePaused": "Game gepauzeerd",
         "hide": "Verbergen",
         "loadingRouteData": "Routegegevens laden...",
         "missing": "Ontbreekt",

--- a/app/types/telemetry.ts
+++ b/app/types/telemetry.ts
@@ -1,3 +1,7 @@
+//-----------------------------------------------------------------------------
+// RenCloud's SCS SDK plugin
+//-----------------------------------------------------------------------------
+
 /**
  * CORE TELEMETRY PACKET
  */
@@ -185,4 +189,91 @@ export interface Delivered {
     distanceKm: number;
     earnedXp: number;
     revenue: number;
+}
+
+//-----------------------------------------------------------------------------
+// TruckTel
+//-----------------------------------------------------------------------------
+
+// Delta-coded: missing key means unchanged from previous packet, null is used
+// to invalidate.
+export interface TruckTelPacket {
+    game?: "eut2" | "ats";
+    posX?: number | null;
+    posY?: number | null;
+    posZ?: number | null;
+    speedKph?: number | null;
+    rawHeading?: number | null;
+    scale?: number | null;
+    speedLimitKph?: number | null;
+    navDist?: number | null;
+    truckBrand?: string | null;
+    truckName?: string | null;
+    trailerAttached?: boolean | null;
+    fuel?: number | null;
+    jobType?: string | null;
+    origCompId?: string | null;
+    origCompName?: string | null;
+    origCityId?: string | null;
+    origCityName?: string | null;
+    destCompId?: string | null;
+    destCompName?: string | null;
+    destCityId?: string | null;
+    destCityName?: string | null;
+    cargoName?: string | null;
+    income?: number | null;
+    restRemain?: number | null;
+    timestamp?: number | null;
+}
+
+//-----------------------------------------------------------------------------
+// Common intermediate representation
+//-----------------------------------------------------------------------------
+
+export interface CommonConnection {
+    connectedToBridge: boolean;
+    simDataValid: boolean;
+    game: string, // ETS2, ATS, or something like "disconnected" probably
+}
+
+export interface CommonNavInfo {
+    position: Vector3,
+    speedKph: number,
+    rawGameHeading: number,
+    mapScale: number,
+    speedLimitKph: number,
+    inGameNavDistance: number,
+}
+
+export interface CommonTruckInfo {
+    brand: string,
+    name: string,
+    trailerAvailable: boolean,
+    trailerAttached: boolean,
+    fuel: number,
+}
+
+export interface CommonCompany {
+    companyName: string;
+    companyId: string;
+    cityName: string;
+    cityId: string;
+}
+
+export interface CommonJobInfo {
+    active: boolean,
+    type: string,
+    origin: CommonCompany,
+    destination: CommonCompany,
+    cargo: string,
+    income: number,
+}
+
+export interface CommonTelemetryData {
+    connection: CommonConnection,
+    nav: CommonNavInfo,
+    job: CommonJobInfo,
+    truck: CommonTruckInfo,
+    gameTimeFormatted: string,
+    nextRestStopMinutes: number,
 }

--- a/app/types/telemetryState.ts
+++ b/app/types/telemetryState.ts
@@ -8,6 +8,7 @@ export interface TelemetryUpdate {
 export interface GameState {
     gameTime: string;
     gameConnected: boolean;
+    simDataValid: boolean;
     hasInGameMarker: boolean;
     scale: number;
 }

--- a/trucktel/README.txt
+++ b/trucktel/README.txt
@@ -1,0 +1,62 @@
+Installation
+============
+
+To install the plugin:
+
+ - Find your game's installation directory. For Steam installs, you can find
+   it by right-clicking the game in your library, and selecting
+   Manage -> Browse Local Files.
+ - You should see a bunch of .scs files and a few directories. Open the "bin"
+   directory.
+ - The "bin" directory should have one directory in it, of which the name
+   depends on your OS. Open it. If this directory has the "amtrucks" or
+   "eurotrucks2" executable in it, you're in the right place.
+ - Extract the TruckNav-on-TruckTel.zip archive to this directory. It should
+   create a "plugins" directory, if it didn't already exist.
+
+
+Using the plugin from a browser
+===============================
+
+You don't need to install anything else if you just want to use TruckNav from a
+web browser.
+
+When you launch the game, you will get a popup in the main menu that reads
+
+    Request to use advanced SDK features detected.
+
+When you acknowledge this, the plugin will load, and you can open the web app.
+YOU CANNOT OPEN THE WEB APP BEFORE THIS TIME, it will not load.
+
+To open the app on a second screen of the computer you're running the game on,
+open a browser and go to http://localhost:30001/. On different devices, you
+can try:
+
+                                       █████████████████████████████████████
+                                       █████████████████████████████████████
+      █▀▀▀▀▀█ █▄▄███▀▀▄  ▀▄ █▀▀▀▀▀█    ████ ▄▄▄▄▄ █ ▀▀   ▄▄▀██▄▀█ ▄▄▄▄▄ ████
+      █ ███ █ ▄▀▀ ▄ ▄▄▀▄█▄▄ █ ███ █    ████ █   █ █▀▄▄█▀█▀▀▄▀ ▀▀█ █   █ ████
+      █ ▀▀▀ █  ▄▄▀ ▄▀▄█▀▀█▀ █ ▀▀▀ █    ████ █▄▄▄█ ██▀▀▄█▀▄▀ ▄▄ ▄█ █▄▄▄█ ████
+      ▀▀▀▀▀▀▀ █ ▀ █ ▀▄█▄▀ ▀ ▀▀▀▀▀▀▀    ████▄▄▄▄▄▄▄█ █▄█ █▄▀ ▀▄█▄█▄▄▄▄▄▄▄████
+      ▀▄▀▀ █▀▀▄█ ███▄█ ▀ ▄▄ █▄▄▀ ▀█    ████▄▀▄▄█ ▄▄▀ █   ▀ █▄█▀▀█ ▀▀▄█▄ ████
+      █▄ ▀ █▀█▄ ▄▄▀▀  █▀ ▄ ▀▄ █▄▀▀▄    ████ ▀█▄█ ▄ ▀█▀▀▄▄██ ▄█▀█▄▀█ ▀▄▄▀████
+      ▄█  ▀█▀▄██  ▄ █▀▄██▄  ▄  ▀▀▄▄    ████▀ ██▄ ▄▀  ██▀█ ▄▀  ▀██▀██▄▄▀▀████
+       █▄▄ █▀▄ █▀█ ▀▄▀█ ▄█▀▀▀▀█▀▀█▀    █████ ▀▀█ ▄▀█ ▄ █▄▀▄ █▀ ▄▄▄▄ ▄▄ ▄████
+      ▀█ ▀█▄▀▀█▀ █▄ █▀█ ▄ █▀ █▀ ▄█     ████▄ █▄ ▀▄▄ ▄█ ▀█ ▄ █▀█ ▄█ ▄█▀ █████
+      ▀ ▄▄▄█▀▀▄ ▄▀▄██▀▀▄█▄▀ ▀▀▀▀█      ████▄█▀▀▀ ▄▄▀█▀▄▀  ▄▄▀ ▀▄█▄▄▄▄ ██████
+       ▀▀ ▀ ▀▀▄ ▀▀█▀▀▄██▄ █▀▀▀███▄▄    █████▄▄█▄█▄▄▀█▄▄ ▄▄▀  ▀█ ▄▄▄   ▀▀████
+      █▀▀▀▀▀█ █ ▀▄ ▄██  █▀█ ▀ █▀ ▀▄    ████ ▄▄▄▄▄ █ █▄▀█▀  ██ ▄ █▄█ ▄█▄▀████
+      █ ███ █ ▄ ▄ ▀   ▀ ▀ █▀▀▀███▄▀    ████ █   █ █▀█▀█▄███▄█▄█ ▄▄▄   ▀▄████
+      █ ▀▀▀ █ ▀▄█▄▄ ▄▄ ██ █ ▄▀ █ ▄▀    ████ █▄▄▄█ █▄▀ ▀▀█▀▀█  █ █▀▄█ █▀▄████
+      ▀▀▀▀▀▀▀ ▀▀ ▀ ▀▀  ▀▀▀▀ ▀▀ ▀ ▀     ████▄▄▄▄▄▄▄█▄▄█▄█▄▄██▄▄▄▄█▄▄█▄█▄█████
+                                       █████████████████████████████████████
+                                       ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+        (for black-on-white text)            (for white-on-black text)
+
+                         http://trucktel.local:30001/
+
+
+If that doesn't work, you can also try replacing trucktel.local with your local
+IP address. If that doesn't work either, your firewall is probably blocking the
+webserver that's built into TruckTel. Make sure to allow network access to the
+game when prompted by your firewall.

--- a/trucktel/config.yaml
+++ b/trucktel/config.yaml
@@ -1,0 +1,87 @@
+---
+port: 30001
+
+content-types:
+  - if: .*\.html?
+    then: text/html; charset=utf-8
+  - if: .*\.json
+    then: application/json; charset=utf-8
+  - if: .*\.js
+    then: text/javascript; charset=utf-8
+  - if: .*\.css
+    then: text/css; charset=utf-8
+  - if: .*\.svg
+    then: image/svg+xml; charset=utf-8
+  - if: .*\.png
+    then: image/png
+  - if: .*\.jpe?g
+    then: image/jpeg
+  - if: .*\.gif
+    then: image/gif
+  - if: .*\.ico
+    then: image/vnd.microsoft.icon
+  - if: .*\.ttf
+    then: font/ttf
+  - if: .*\.webp
+    then: image/webp
+
+custom-structures:
+  nav:
+    game:
+      key: game.id
+    posX:
+      key: truck.world.placement.0
+    posY:
+      key: truck.world.placement.1
+    posZ:
+      key: truck.world.placement.2
+    speedKph:
+      key: truck.speed
+      scale: 3.6 # to km/h
+      operator: round
+    rawHeading:
+      key: truck.world.placement.3
+    scale:
+      key: local.scale
+    speedLimitKph:
+      key: truck.navigation.speed.limit
+      scale: 3.6 # to km/h
+      operator: round
+    navDist:
+      key: truck.navigation.distance
+      operator: round
+    truckBrand:
+      key: truck.brand
+    truckName:
+      key: truck.name
+    trailerAttached:
+      key: trailer.0.connected
+    fuel:
+      key: truck.fuel.amount
+      operator: round
+    jobType:
+      key: job.job.market
+    origCompId:
+      key: job.source.company.id
+    origCompName:
+      key: job.source.company
+    origCityId:
+      key: job.source.city.id
+    origCityName:
+      key: job.source.city
+    destCompId:
+      key: job.destination.company.id
+    destCompName:
+      key: job.destination.company
+    destCityId:
+      key: job.destination.city.id
+    destCityName:
+      key: job.destination.city
+    cargoName:
+      key: job.cargo
+    income:
+      key: job.income
+    restRemain:
+      key: rest.stop
+    timestamp:
+      key: game.time


### PR DESCRIPTION
Continuing here from https://github.com/Rares-Muntean/TruckNav-Sim/issues/31, here's an actual attempt at properly integrating support for TruckTel, now that I've been working on my own Vue app for a few weeks and have some more experience. Still a work in progress, but it plays quite nicely together with TruckNav...

<img width="300" alt="image" src="https://github.com/user-attachments/assets/0ecc5ea8-16f0-405b-8fdf-739ff6091a46" />

Integration notes:

 - The changes *should* not affect anything for the existing installation methods and workflows, though I don't have the environment to test it for sure.
 - The telemetry logic initially attempts to connect to the telemetry bridge at :30001 as it normally would. When you do this with TruckTel, it closes the connection immediately, because that's an HTTP endpoint. The close handler detects this, and then immediately reconnects in TruckTel mode.
 - Telemetry packets are first converted to a sane-ish format common to the telemetry bridge and TruckTel. I think TruckTel could be convinced to mimic most of what the bridge is doing, but that's a LOT of extra data to implement that TruckNav isn't currently using.
 - I changed some UI logic surrounding connection state. I'm not sure what the bridge does when the user hasn't fully loaded the game and unpaused yet (maybe it just pretends that the game isn't connected yet? idk), but TruckTel in this case sends nulls for most simulation data, because that's what the game's telemetry API does. It doesn't make sense to show a "game disconnected" message in the top bar to hide the invalid data in this case, because the game is connected just fine and job data is valid. Just hiding the invalid data didn't look right, so I added a "paused" overlay for this.
 - I also added some logic to the game selection screen. On load, it tries to query `/api/rest/single/game/id`. When running from TruckTel, this will return the game ID immediately, and the manual selection screen will be skipped. When running from `npx nuxi dev`, it'll fetch a resource from the development server that doesn't exist, and it shows the manual selection screen. I'm not 100% sure what happens when running from Electron or an app, but I'm assuming the fetch API would either return a 404 or scream bloody murder; in either case, the exception should be caught and the manual selection screen be shown. Just in case, I also added a very strict timeout; the response from TruckTel should be basically instant anyway.
 - I didn't change any installer logic. IMO, the whole point of using TruckTel over the existing install methods for TruckNav is to not have to do more than extract a few files in the game directory. Instead, I added an actions workflow that builds a zip file with the latest TruckTel release, the statically rendered Nuxt app, the appropriate configuration file for TruckTel, and a file with basic install instructions. I tested the action on my own repo's master, not sure how to do that in the PR.
 - I didn't modify the main README file yet. I figure you'd probably want to do your own testing first.
 - I'm not sure if you're using a formatter like prettier. I saw the .prettierignore file so I figured you were, but it wreaked havoc on the whole repo, so my additions are manually formatted.